### PR TITLE
chore: CHAL-0003 add Railway deployment config for go-service

### DIFF
--- a/go-service/railway.toml
+++ b/go-service/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "./Dockerfile"
+watchPatterns = ["/go-service/**"]
+
+[deploy]
+healthcheckPath = "/api/v1/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 5

--- a/scripts/railway-setup.sh
+++ b/scripts/railway-setup.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 BACKEND_ENV="${PROJECT_DIR}/backend/.env"
 FRONTEND_ENV="${PROJECT_DIR}/frontend/.env"
+GO_SERVICE_ENV="${PROJECT_DIR}/go-service/.env"
 SEED_DIR="${PROJECT_DIR}/seed_db"
 
 # ============================================================
@@ -33,9 +34,15 @@ if [ ! -f "$FRONTEND_ENV" ]; then
   exit 1
 fi
 
+if [ ! -f "$GO_SERVICE_ENV" ]; then
+  echo "Error: go-service/.env not found"
+  exit 1
+fi
+
 echo "==> Using env files as source of truth"
-echo "    Backend:  ${BACKEND_ENV}"
-echo "    Frontend: ${FRONTEND_ENV}"
+echo "    Backend:     ${BACKEND_ENV}"
+echo "    Frontend:    ${FRONTEND_ENV}"
+echo "    Go Service:  ${GO_SERVICE_ENV}"
 
 # ============================================================
 # 1. Seed the database
@@ -109,12 +116,27 @@ railway variable set --service frontend \
 echo "==> Frontend variables set."
 
 # ============================================================
-# 5. Summary
+# 5. Set go-service environment variables
+# ============================================================
+echo ""
+echo "==> Setting go-service environment variables (from go-service/.env)..."
+GO_SERVICE_DOMAIN=$(railway domain --service go-service 2>&1 | grep -oP 'https://\S+' || true)
+echo "    Go Service: ${GO_SERVICE_DOMAIN}"
+
+railway variable set --service go-service \
+  "PORT=$(env_val "$GO_SERVICE_ENV" PORT)" \
+  'DATABASE_URL=${{Postgres.DATABASE_URL}}'
+
+echo "==> Go-service variables set."
+
+# ============================================================
+# 6. Summary
 # ============================================================
 echo ""
 echo "==> Railway setup complete!"
-echo "    Frontend: ${FRONTEND_DOMAIN}"
-echo "    Backend:  ${BACKEND_DOMAIN}"
+echo "    Frontend:    ${FRONTEND_DOMAIN}"
+echo "    Backend:     ${BACKEND_DOMAIN}"
+echo "    Go Service:  ${GO_SERVICE_DOMAIN}"
 echo ""
 echo "NOTE: The secrets in backend/.env are dev defaults."
 echo "      For real production, update backend/.env with strong"

--- a/scripts/railway-setup.sh
+++ b/scripts/railway-setup.sh
@@ -49,7 +49,7 @@ echo "    Go Service:  ${GO_SERVICE_ENV}"
 # ============================================================
 echo ""
 echo "==> Fetching Postgres credentials from Railway..."
-DB_PUBLIC_URL=$(railway variable get DATABASE_PUBLIC_URL --service Postgres 2>/dev/null || true)
+DB_PUBLIC_URL=$(railway variable --json --service Postgres 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('DATABASE_PUBLIC_URL',''))" 2>/dev/null || true)
 
 if [ -z "$DB_PUBLIC_URL" ]; then
   echo "Error: Could not fetch DATABASE_PUBLIC_URL from Railway Postgres service."


### PR DESCRIPTION
## Summary
- Add `go-service/railway.toml` with Dockerfile builder, health check at `/api/v1/health`, and restart policy
- Update `scripts/railway-setup.sh` to configure go-service env vars (`PORT`, `DATABASE_URL` via Postgres reference variable) and generate a Railway domain

## Test plan
- [ ] Verify `railway-setup.sh` runs without errors and sets go-service variables
- [ ] Confirm go-service deploys and health check passes on Railway
- [ ] Verify go-service can connect to the shared Postgres instance