### PR TITLE
fix: CHAL-0005 add new notice description not saving

### DIFF
--- a/frontend/src/domains/notice/components/notice-form.tsx
+++ b/frontend/src/domains/notice/components/notice-form.tsx
@@ -86,7 +86,7 @@ export const NoticeForm: React.FC<Props> = ({
         sx={{ marginTop: '20px' }}
       />
       <TextField
-        {...register('content')}
+        {...register('description')}
         error={Boolean(errors.description)}
         helperText={errors.description?.message}
         type='text'

--- a/frontend/src/domains/notice/pages/add-notice-page.tsx
+++ b/frontend/src/domains/notice/pages/add-notice-page.tsx
@@ -16,7 +16,7 @@ import { NoticeForm } from '../components';
 
 const initialState: NoticeFormProps = {
   title: '',
-  content: '',
+  description: '',
   status: 0,
   recipientType: 'EV',
   recipientRole: 0,


### PR DESCRIPTION
## Summary
- Fixed field name mismatch in the Add Notice form where the description TextField was registered as `content` instead of `description`
- Aligned the form initial state key from `content` to `description` to match the Zod schema and backend API expectation
- Without this fix, the description value was never bound to the validated field, so it was either blocked by validation or lost in the API payload

## Test plan
- [x] Navigate to `/app/notices/add`
- [x] Fill in all fields including description
- [x] Submit the form and verify the notice is created with the correct description
- [x] Verify validation error displays when description is left empty