### PR TITLE
fix: CHAL-0008 form validation, submission consistency and UI/UX bug fixes

### DIFF
--- a/backend/src/modules/access-control/access-control-router.ts
+++ b/backend/src/modules/access-control/access-control-router.ts
@@ -2,14 +2,33 @@ import { Router } from 'express';
 import * as accessControlController from './access-control-controller';
 import { isUserAdmin } from '../../middlewares';
 import { validateRequest } from '../../utils';
-import { accessControlIdParamSchema, addAccessControlSchema, updateAccessControlSchema } from './access-control-schema';
+import {
+  accessControlIdParamSchema,
+  addAccessControlSchema,
+  updateAccessControlSchema
+} from './access-control-schema';
 
 const router = Router();
 
 router.get('', isUserAdmin, accessControlController.handleGetAllAccessControls);
-router.post('', isUserAdmin, validateRequest(addAccessControlSchema), accessControlController.handleAddAccessControl);
-router.put('/:id', isUserAdmin, validateRequest(updateAccessControlSchema), accessControlController.handleUpdateAccessControl);
-router.delete('/:id', isUserAdmin, validateRequest(accessControlIdParamSchema), accessControlController.handleDeleteAccessControl);
+router.post(
+  '',
+  isUserAdmin,
+  validateRequest(addAccessControlSchema),
+  accessControlController.handleAddAccessControl
+);
+router.put(
+  '/:id',
+  isUserAdmin,
+  validateRequest(updateAccessControlSchema),
+  accessControlController.handleUpdateAccessControl
+);
+router.delete(
+  '/:id',
+  isUserAdmin,
+  validateRequest(accessControlIdParamSchema),
+  accessControlController.handleDeleteAccessControl
+);
 router.get('/me', accessControlController.handleGetMyAccessControl);
 
 export { router as accessControlRoutes };

--- a/backend/src/modules/access-control/access-control-router.ts
+++ b/backend/src/modules/access-control/access-control-router.ts
@@ -1,13 +1,15 @@
 import { Router } from 'express';
 import * as accessControlController from './access-control-controller';
 import { isUserAdmin } from '../../middlewares';
+import { validateRequest } from '../../utils';
+import { accessControlIdParamSchema, addAccessControlSchema, updateAccessControlSchema } from './access-control-schema';
 
 const router = Router();
 
 router.get('', isUserAdmin, accessControlController.handleGetAllAccessControls);
-router.post('', isUserAdmin, accessControlController.handleAddAccessControl);
-router.put('/:id', isUserAdmin, accessControlController.handleUpdateAccessControl);
-router.delete('/:id', isUserAdmin, accessControlController.handleDeleteAccessControl);
+router.post('', isUserAdmin, validateRequest(addAccessControlSchema), accessControlController.handleAddAccessControl);
+router.put('/:id', isUserAdmin, validateRequest(updateAccessControlSchema), accessControlController.handleUpdateAccessControl);
+router.delete('/:id', isUserAdmin, validateRequest(accessControlIdParamSchema), accessControlController.handleDeleteAccessControl);
 router.get('/me', accessControlController.handleGetMyAccessControl);
 
 export { router as accessControlRoutes };

--- a/backend/src/modules/access-control/access-control-schema.ts
+++ b/backend/src/modules/access-control/access-control-schema.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+const idParam = z.object({
+    id: z.string().regex(/^\d+$/, "ID must be a number"),
+});
+
+export const accessControlIdParamSchema = z.object({
+    params: idParam,
+});
+
+export const addAccessControlSchema = z.object({
+    body: z.object({
+        name: z.string().min(1, "Name is required"),
+        type: z.string().min(1, "Type is required"),
+        path: z.string().optional(),
+        method: z.string().optional(),
+    }),
+});
+
+export const updateAccessControlSchema = z.object({
+    params: idParam,
+    body: z.object({
+        name: z.string().min(1, "Name is required"),
+        type: z.string().min(1, "Type is required"),
+        path: z.string().optional(),
+        method: z.string().optional(),
+    }),
+});

--- a/backend/src/modules/access-control/access-control-schema.ts
+++ b/backend/src/modules/access-control/access-control-schema.ts
@@ -8,21 +8,19 @@ export const accessControlIdParamSchema = z.object({
   params: idParam
 });
 
+const accessControlBodyFields = {
+  name: z.string().min(1, 'Name is required'),
+  type: z.string().min(1, 'Type is required'),
+  path: z.string().optional(),
+  method: z.string().optional(),
+  hierarchy_id: z.number().optional()
+};
+
 export const addAccessControlSchema = z.object({
-  body: z.object({
-    name: z.string().min(1, 'Name is required'),
-    type: z.string().min(1, 'Type is required'),
-    path: z.string().optional(),
-    method: z.string().optional()
-  })
+  body: z.object(accessControlBodyFields)
 });
 
 export const updateAccessControlSchema = z.object({
   params: idParam,
-  body: z.object({
-    name: z.string().min(1, 'Name is required'),
-    type: z.string().min(1, 'Type is required'),
-    path: z.string().optional(),
-    method: z.string().optional()
-  })
+  body: z.object(accessControlBodyFields)
 });

--- a/backend/src/modules/access-control/access-control-schema.ts
+++ b/backend/src/modules/access-control/access-control-schema.ts
@@ -1,28 +1,28 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 const idParam = z.object({
-    id: z.string().regex(/^\d+$/, "ID must be a number"),
+  id: z.string().regex(/^\d+$/, 'ID must be a number')
 });
 
 export const accessControlIdParamSchema = z.object({
-    params: idParam,
+  params: idParam
 });
 
 export const addAccessControlSchema = z.object({
-    body: z.object({
-        name: z.string().min(1, "Name is required"),
-        type: z.string().min(1, "Type is required"),
-        path: z.string().optional(),
-        method: z.string().optional(),
-    }),
+  body: z.object({
+    name: z.string().min(1, 'Name is required'),
+    type: z.string().min(1, 'Type is required'),
+    path: z.string().optional(),
+    method: z.string().optional()
+  })
 });
 
 export const updateAccessControlSchema = z.object({
-    params: idParam,
-    body: z.object({
-        name: z.string().min(1, "Name is required"),
-        type: z.string().min(1, "Type is required"),
-        path: z.string().optional(),
-        method: z.string().optional(),
-    }),
+  params: idParam,
+  body: z.object({
+    name: z.string().min(1, 'Name is required'),
+    type: z.string().min(1, 'Type is required'),
+    path: z.string().optional(),
+    method: z.string().optional()
+  })
 });

--- a/backend/src/modules/account/account-router.ts
+++ b/backend/src/modules/account/account-router.ts
@@ -5,7 +5,11 @@ import { changePasswordSchema } from './account-schema';
 
 const router = Router();
 
-router.post('/change-password', validateRequest(changePasswordSchema), accountController.handlePasswordChange);
+router.post(
+  '/change-password',
+  validateRequest(changePasswordSchema),
+  accountController.handlePasswordChange
+);
 router.get('/me', accountController.handleGetAccountDetail);
 
 export { router as accountRoutes };

--- a/backend/src/modules/account/account-router.ts
+++ b/backend/src/modules/account/account-router.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 import * as accountController from './account-controller';
+import { validateRequest } from '../../utils';
+import { changePasswordSchema } from './account-schema';
 
 const router = Router();
 
-router.post('/change-password', accountController.handlePasswordChange);
+router.post('/change-password', validateRequest(changePasswordSchema), accountController.handlePasswordChange);
 router.get('/me', accountController.handleGetAccountDetail);
 
 export { router as accountRoutes };

--- a/backend/src/modules/account/account-schema.ts
+++ b/backend/src/modules/account/account-schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const changePasswordSchema = z.object({
+    body: z.object({
+        oldPassword: z.string().min(1, "Old password is required"),
+        newPassword: z.string().min(6, "New password must be at least 6 characters"),
+    }),
+});

--- a/backend/src/modules/account/account-schema.ts
+++ b/backend/src/modules/account/account-schema.ts
@@ -1,8 +1,8 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 export const changePasswordSchema = z.object({
-    body: z.object({
-        oldPassword: z.string().min(1, "Old password is required"),
-        newPassword: z.string().min(6, "New password must be at least 6 characters"),
-    }),
+  body: z.object({
+    oldPassword: z.string().min(1, 'Old password is required'),
+    newPassword: z.string().min(6, 'New password must be at least 6 characters')
+  })
 });

--- a/backend/src/modules/account/account-service.ts
+++ b/backend/src/modules/account/account-service.ts
@@ -14,6 +14,7 @@ import {
   getStaffAccountDetail
 } from './account-repository';
 import { insertRefreshToken, findUserById } from '../../shared/repository';
+import { deleteOldRefreshTokenByUserId } from '../auth/auth-repository';
 
 interface PasswordChangePayload {
   userId: number;
@@ -65,6 +66,7 @@ const processPasswordChange = async (
       env.JWT_REFRESH_TOKEN_TIME_IN_MS!
     );
 
+    await deleteOldRefreshTokenByUserId(userId, client);
     await insertRefreshToken({ userId, refreshToken }, client);
 
     await client.query('COMMIT');

--- a/backend/src/modules/auth/auth-controller.ts
+++ b/backend/src/modules/auth/auth-controller.ts
@@ -34,7 +34,7 @@ export const handleLogout = asyncHandler(async (req: Request, res: Response): Pr
   const message = await logout(refreshToken);
   clearAllCookies(res);
 
-  res.status(204).json(message);
+  res.json(message);
 });
 
 export const handleTokenRefresh = asyncHandler(

--- a/backend/src/modules/auth/auth-router.ts
+++ b/backend/src/modules/auth/auth-router.ts
@@ -1,10 +1,10 @@
 import { Router } from 'express';
 import {
-    authenticateToken,
-    csrfProtection,
-    handleEmailVerificationToken,
-    handlePasswordSetupToken,
-    checkApiAccess,
+  authenticateToken,
+  csrfProtection,
+  handleEmailVerificationToken,
+  handlePasswordSetupToken,
+  checkApiAccess
 } from '../../middlewares';
 import * as authController from './auth-controller';
 import { validateRequest } from '../../utils';
@@ -15,10 +15,37 @@ const router = Router();
 router.post('/login', validateRequest(LoginSchema), authController.handleLogin);
 router.get('/refresh', authController.handleTokenRefresh);
 router.post('/logout', authenticateToken, csrfProtection, authController.handleLogout);
-router.get('/verify-email/:token', handleEmailVerificationToken, authController.handleAccountEmailVerify);
-router.post('/setup-password', handlePasswordSetupToken, validateRequest(SetupPasswordSchema), authController.handleAccountPasswordSetup);
-router.post('/resend-email-verification', authenticateToken, csrfProtection, checkApiAccess, authController.handleResendEmailVerification);
-router.post('/resend-pwd-setup-link', authenticateToken, csrfProtection, checkApiAccess, authController.handleResendPwdSetupLink);
-router.post('/reset-pwd', authenticateToken, csrfProtection, checkApiAccess, authController.handlePwdReset);
+router.get(
+  '/verify-email/:token',
+  handleEmailVerificationToken,
+  authController.handleAccountEmailVerify
+);
+router.post(
+  '/setup-password',
+  handlePasswordSetupToken,
+  validateRequest(SetupPasswordSchema),
+  authController.handleAccountPasswordSetup
+);
+router.post(
+  '/resend-email-verification',
+  authenticateToken,
+  csrfProtection,
+  checkApiAccess,
+  authController.handleResendEmailVerification
+);
+router.post(
+  '/resend-pwd-setup-link',
+  authenticateToken,
+  csrfProtection,
+  checkApiAccess,
+  authController.handleResendPwdSetupLink
+);
+router.post(
+  '/reset-pwd',
+  authenticateToken,
+  csrfProtection,
+  checkApiAccess,
+  authController.handlePwdReset
+);
 
 export { router as authRoutes };

--- a/backend/src/modules/auth/auth-router.ts
+++ b/backend/src/modules/auth/auth-router.ts
@@ -1,46 +1,24 @@
 import { Router } from 'express';
 import {
-  authenticateToken,
-  csrfProtection,
-  handleEmailVerificationToken,
-  handlePasswordSetupToken,
-  checkApiAccess
+    authenticateToken,
+    csrfProtection,
+    handleEmailVerificationToken,
+    handlePasswordSetupToken,
+    checkApiAccess,
 } from '../../middlewares';
 import * as authController from './auth-controller';
 import { validateRequest } from '../../utils';
-import { LoginSchema } from './auth-schema';
+import { LoginSchema, SetupPasswordSchema } from './auth-schema';
 
 const router = Router();
 
 router.post('/login', validateRequest(LoginSchema), authController.handleLogin);
 router.get('/refresh', authController.handleTokenRefresh);
 router.post('/logout', authenticateToken, csrfProtection, authController.handleLogout);
-router.get(
-  '/verify-email/:token',
-  handleEmailVerificationToken,
-  authController.handleAccountEmailVerify
-);
-router.post('/setup-password', handlePasswordSetupToken, authController.handleAccountPasswordSetup);
-router.post(
-  '/resend-email-verification',
-  authenticateToken,
-  csrfProtection,
-  checkApiAccess,
-  authController.handleResendEmailVerification
-);
-router.post(
-  '/resend-pwd-setup-link',
-  authenticateToken,
-  csrfProtection,
-  checkApiAccess,
-  authController.handleResendPwdSetupLink
-);
-router.post(
-  '/reset-pwd',
-  authenticateToken,
-  csrfProtection,
-  checkApiAccess,
-  authController.handlePwdReset
-);
+router.get('/verify-email/:token', handleEmailVerificationToken, authController.handleAccountEmailVerify);
+router.post('/setup-password', handlePasswordSetupToken, validateRequest(SetupPasswordSchema), authController.handleAccountPasswordSetup);
+router.post('/resend-email-verification', authenticateToken, csrfProtection, checkApiAccess, authController.handleResendEmailVerification);
+router.post('/resend-pwd-setup-link', authenticateToken, csrfProtection, checkApiAccess, authController.handleResendPwdSetupLink);
+router.post('/reset-pwd', authenticateToken, csrfProtection, checkApiAccess, authController.handlePwdReset);
 
 export { router as authRoutes };

--- a/backend/src/modules/auth/auth-schema.ts
+++ b/backend/src/modules/auth/auth-schema.ts
@@ -8,8 +8,8 @@ export const LoginSchema = z.object({
 });
 
 export const SetupPasswordSchema = z.object({
-    body: z.object({
-        username: z.string().min(1, "Username is required"),
-        password: z.string().min(6, "Password must be at least 6 characters long"),
-    })
+  body: z.object({
+    username: z.string().min(1, 'Username is required'),
+    password: z.string().min(6, 'Password must be at least 6 characters long')
+  })
 });

--- a/backend/src/modules/auth/auth-schema.ts
+++ b/backend/src/modules/auth/auth-schema.ts
@@ -6,3 +6,10 @@ export const LoginSchema = z.object({
     password: z.string().min(6, 'Password must be at least 6 characters long')
   })
 });
+
+export const SetupPasswordSchema = z.object({
+    body: z.object({
+        username: z.string().min(1, "Username is required"),
+        password: z.string().min(6, "Password must be at least 6 characters long"),
+    })
+});

--- a/backend/src/modules/class-teacher/class-teacher-router.ts
+++ b/backend/src/modules/class-teacher/class-teacher-router.ts
@@ -1,12 +1,14 @@
 import { Router } from 'express';
 import * as classTeacherController from './class-teacher-controller';
 import { checkApiAccess } from '../../middlewares';
+import { validateRequest } from '../../utils';
+import { classTeacherIdParamSchema, addClassTeacherSchema, updateClassTeacherSchema } from './class-teacher-schema';
 
 const router = Router();
 
 router.get('', checkApiAccess, classTeacherController.handleGetClassTeachers);
-router.post('', checkApiAccess, classTeacherController.handleAddClassTeacher);
-router.get('/:id', checkApiAccess, classTeacherController.handleGetClassTeacherDetail);
-router.put('/:id', checkApiAccess, classTeacherController.handleUpdateClassTeacherDetail);
+router.post('', checkApiAccess, validateRequest(addClassTeacherSchema), classTeacherController.handleAddClassTeacher);
+router.get('/:id', checkApiAccess, validateRequest(classTeacherIdParamSchema), classTeacherController.handleGetClassTeacherDetail);
+router.put('/:id', checkApiAccess, validateRequest(updateClassTeacherSchema), classTeacherController.handleUpdateClassTeacherDetail);
 
 export { router as classTeacherRoutes };

--- a/backend/src/modules/class-teacher/class-teacher-router.ts
+++ b/backend/src/modules/class-teacher/class-teacher-router.ts
@@ -2,13 +2,32 @@ import { Router } from 'express';
 import * as classTeacherController from './class-teacher-controller';
 import { checkApiAccess } from '../../middlewares';
 import { validateRequest } from '../../utils';
-import { classTeacherIdParamSchema, addClassTeacherSchema, updateClassTeacherSchema } from './class-teacher-schema';
+import {
+  classTeacherIdParamSchema,
+  addClassTeacherSchema,
+  updateClassTeacherSchema
+} from './class-teacher-schema';
 
 const router = Router();
 
 router.get('', checkApiAccess, classTeacherController.handleGetClassTeachers);
-router.post('', checkApiAccess, validateRequest(addClassTeacherSchema), classTeacherController.handleAddClassTeacher);
-router.get('/:id', checkApiAccess, validateRequest(classTeacherIdParamSchema), classTeacherController.handleGetClassTeacherDetail);
-router.put('/:id', checkApiAccess, validateRequest(updateClassTeacherSchema), classTeacherController.handleUpdateClassTeacherDetail);
+router.post(
+  '',
+  checkApiAccess,
+  validateRequest(addClassTeacherSchema),
+  classTeacherController.handleAddClassTeacher
+);
+router.get(
+  '/:id',
+  checkApiAccess,
+  validateRequest(classTeacherIdParamSchema),
+  classTeacherController.handleGetClassTeacherDetail
+);
+router.put(
+  '/:id',
+  checkApiAccess,
+  validateRequest(updateClassTeacherSchema),
+  classTeacherController.handleUpdateClassTeacherDetail
+);
 
 export { router as classTeacherRoutes };

--- a/backend/src/modules/class-teacher/class-teacher-schema.ts
+++ b/backend/src/modules/class-teacher/class-teacher-schema.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+const idParam = z.object({
+    id: z.string().regex(/^\d+$/, "ID must be a number"),
+});
+
+export const classTeacherIdParamSchema = z.object({
+    params: idParam,
+});
+
+export const addClassTeacherSchema = z.object({
+    body: z.object({
+        class: z.string().min(1, "Class is required"),
+        section: z.string(),
+        teacher: z.number().min(1, "Teacher is required"),
+    }),
+});
+
+export const updateClassTeacherSchema = z.object({
+    params: idParam,
+    body: z.object({
+        class: z.string().min(1, "Class is required"),
+        section: z.string(),
+        teacher: z.number().min(1, "Teacher is required"),
+    }),
+});

--- a/backend/src/modules/class-teacher/class-teacher-schema.ts
+++ b/backend/src/modules/class-teacher/class-teacher-schema.ts
@@ -1,26 +1,26 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 const idParam = z.object({
-    id: z.string().regex(/^\d+$/, "ID must be a number"),
+  id: z.string().regex(/^\d+$/, 'ID must be a number')
 });
 
 export const classTeacherIdParamSchema = z.object({
-    params: idParam,
+  params: idParam
 });
 
 export const addClassTeacherSchema = z.object({
-    body: z.object({
-        class: z.string().min(1, "Class is required"),
-        section: z.string(),
-        teacher: z.number().min(1, "Teacher is required"),
-    }),
+  body: z.object({
+    class: z.string().min(1, 'Class is required'),
+    section: z.string(),
+    teacher: z.number().min(1, 'Teacher is required')
+  })
 });
 
 export const updateClassTeacherSchema = z.object({
-    params: idParam,
-    body: z.object({
-        class: z.string().min(1, "Class is required"),
-        section: z.string(),
-        teacher: z.number().min(1, "Teacher is required"),
-    }),
+  params: idParam,
+  body: z.object({
+    class: z.string().min(1, 'Class is required'),
+    section: z.string(),
+    teacher: z.number().min(1, 'Teacher is required')
+  })
 });

--- a/backend/src/modules/class-teacher/class-teacher-service.ts
+++ b/backend/src/modules/class-teacher/class-teacher-service.ts
@@ -9,11 +9,7 @@ import {
 
 const fetchAllClassTeachers = async (): Promise<any[]> => {
   const data = await getClassTeachers();
-  if (!Array.isArray(data) || data.length <= 0) {
-    throw new ApiError(404, 'Class teachers not found');
-  }
-
-  return data;
+  return Array.isArray(data) ? data : [];
 };
 
 const addNewClassTeacher = async (payload: {

--- a/backend/src/modules/classes/classes-router.ts
+++ b/backend/src/modules/classes/classes-router.ts
@@ -1,13 +1,15 @@
 import { Router } from 'express';
 import * as classesController from './classes-controller';
 import { checkApiAccess } from '../../middlewares';
+import { validateRequest } from '../../utils';
+import { classIdParamSchema, addClassSchema, updateClassSchema } from './classes-schema';
 
 const router = Router();
 
 router.get('', checkApiAccess, classesController.handleFetchAllClasses);
-router.get('/:id', checkApiAccess, classesController.handleFetchClassDetail);
-router.post('', checkApiAccess, classesController.handleAddClass);
-router.put('/:id', checkApiAccess, classesController.handleUpdateClass);
-router.delete('/:id', checkApiAccess, classesController.handleDeleteClass);
+router.get('/:id', checkApiAccess, validateRequest(classIdParamSchema), classesController.handleFetchClassDetail);
+router.post('', checkApiAccess, validateRequest(addClassSchema), classesController.handleAddClass);
+router.put('/:id', checkApiAccess, validateRequest(updateClassSchema), classesController.handleUpdateClass);
+router.delete('/:id', checkApiAccess, validateRequest(classIdParamSchema), classesController.handleDeleteClass);
 
 export { router as classesRoutes };

--- a/backend/src/modules/classes/classes-router.ts
+++ b/backend/src/modules/classes/classes-router.ts
@@ -7,9 +7,24 @@ import { classIdParamSchema, addClassSchema, updateClassSchema } from './classes
 const router = Router();
 
 router.get('', checkApiAccess, classesController.handleFetchAllClasses);
-router.get('/:id', checkApiAccess, validateRequest(classIdParamSchema), classesController.handleFetchClassDetail);
+router.get(
+  '/:id',
+  checkApiAccess,
+  validateRequest(classIdParamSchema),
+  classesController.handleFetchClassDetail
+);
 router.post('', checkApiAccess, validateRequest(addClassSchema), classesController.handleAddClass);
-router.put('/:id', checkApiAccess, validateRequest(updateClassSchema), classesController.handleUpdateClass);
-router.delete('/:id', checkApiAccess, validateRequest(classIdParamSchema), classesController.handleDeleteClass);
+router.put(
+  '/:id',
+  checkApiAccess,
+  validateRequest(updateClassSchema),
+  classesController.handleUpdateClass
+);
+router.delete(
+  '/:id',
+  checkApiAccess,
+  validateRequest(classIdParamSchema),
+  classesController.handleDeleteClass
+);
 
 export { router as classesRoutes };

--- a/backend/src/modules/classes/classes-schema.ts
+++ b/backend/src/modules/classes/classes-schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+const idParam = z.object({
+    id: z.string().regex(/^\d+$/, "ID must be a number"),
+});
+
+export const classIdParamSchema = z.object({
+    params: idParam,
+});
+
+export const addClassSchema = z.object({
+    body: z.object({
+        name: z.string().min(1, "Class name is required"),
+        sections: z.union([z.array(z.string()), z.string()]),
+    }),
+});
+
+export const updateClassSchema = z.object({
+    params: idParam,
+    body: z.object({
+        name: z.string().min(1, "Class name is required"),
+        sections: z.union([z.array(z.string()), z.string()]),
+    }),
+});

--- a/backend/src/modules/classes/classes-schema.ts
+++ b/backend/src/modules/classes/classes-schema.ts
@@ -1,24 +1,24 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 const idParam = z.object({
-    id: z.string().regex(/^\d+$/, "ID must be a number"),
+  id: z.string().regex(/^\d+$/, 'ID must be a number')
 });
 
 export const classIdParamSchema = z.object({
-    params: idParam,
+  params: idParam
 });
 
 export const addClassSchema = z.object({
-    body: z.object({
-        name: z.string().min(1, "Class name is required"),
-        sections: z.union([z.array(z.string()), z.string()]),
-    }),
+  body: z.object({
+    name: z.string().min(1, 'Class name is required'),
+    sections: z.union([z.array(z.string()), z.string()])
+  })
 });
 
 export const updateClassSchema = z.object({
-    params: idParam,
-    body: z.object({
-        name: z.string().min(1, "Class name is required"),
-        sections: z.union([z.array(z.string()), z.string()]),
-    }),
+  params: idParam,
+  body: z.object({
+    name: z.string().min(1, 'Class name is required'),
+    sections: z.union([z.array(z.string()), z.string()])
+  })
 });

--- a/backend/src/modules/departments/department-router.ts
+++ b/backend/src/modules/departments/department-router.ts
@@ -1,14 +1,30 @@
 import { Router } from 'express';
 import * as departmentController from './department-controller';
 import { validateRequest } from '../../utils';
-import { departmentIdParamSchema, addDepartmentSchema, updateDepartmentSchema } from './department-schema';
+import {
+  departmentIdParamSchema,
+  addDepartmentSchema,
+  updateDepartmentSchema
+} from './department-schema';
 
 const router = Router();
 
 router.get('', departmentController.handleGetAllDepartments);
 router.post('', validateRequest(addDepartmentSchema), departmentController.handleAddNewDepartment);
-router.get('/:id', validateRequest(departmentIdParamSchema), departmentController.handleGetDepartmentById);
-router.put('/:id', validateRequest(updateDepartmentSchema), departmentController.handleUpdateDepartmentById);
-router.delete('/:id', validateRequest(departmentIdParamSchema), departmentController.handleDeleteDepartmentById);
+router.get(
+  '/:id',
+  validateRequest(departmentIdParamSchema),
+  departmentController.handleGetDepartmentById
+);
+router.put(
+  '/:id',
+  validateRequest(updateDepartmentSchema),
+  departmentController.handleUpdateDepartmentById
+);
+router.delete(
+  '/:id',
+  validateRequest(departmentIdParamSchema),
+  departmentController.handleDeleteDepartmentById
+);
 
 export { router as departmentRoutes };

--- a/backend/src/modules/departments/department-router.ts
+++ b/backend/src/modules/departments/department-router.ts
@@ -1,12 +1,14 @@
 import { Router } from 'express';
 import * as departmentController from './department-controller';
+import { validateRequest } from '../../utils';
+import { departmentIdParamSchema, addDepartmentSchema, updateDepartmentSchema } from './department-schema';
 
 const router = Router();
 
 router.get('', departmentController.handleGetAllDepartments);
-router.post('', departmentController.handleAddNewDepartment);
-router.get('/:id', departmentController.handleGetDepartmentById);
-router.put('/:id', departmentController.handleUpdateDepartmentById);
-router.delete('/:id', departmentController.handleDeleteDepartmentById);
+router.post('', validateRequest(addDepartmentSchema), departmentController.handleAddNewDepartment);
+router.get('/:id', validateRequest(departmentIdParamSchema), departmentController.handleGetDepartmentById);
+router.put('/:id', validateRequest(updateDepartmentSchema), departmentController.handleUpdateDepartmentById);
+router.delete('/:id', validateRequest(departmentIdParamSchema), departmentController.handleDeleteDepartmentById);
 
 export { router as departmentRoutes };

--- a/backend/src/modules/departments/department-schema.ts
+++ b/backend/src/modules/departments/department-schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+const idParam = z.object({
+    id: z.string().regex(/^\d+$/, "ID must be a number"),
+});
+
+export const departmentIdParamSchema = z.object({
+    params: idParam,
+});
+
+export const addDepartmentSchema = z.object({
+    body: z.object({
+        name: z.string().min(1, "Department name is required"),
+    }),
+});
+
+export const updateDepartmentSchema = z.object({
+    params: idParam,
+    body: z.object({
+        name: z.string().min(1, "Department name is required"),
+    }),
+});

--- a/backend/src/modules/departments/department-schema.ts
+++ b/backend/src/modules/departments/department-schema.ts
@@ -1,22 +1,22 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 const idParam = z.object({
-    id: z.string().regex(/^\d+$/, "ID must be a number"),
+  id: z.string().regex(/^\d+$/, 'ID must be a number')
 });
 
 export const departmentIdParamSchema = z.object({
-    params: idParam,
+  params: idParam
 });
 
 export const addDepartmentSchema = z.object({
-    body: z.object({
-        name: z.string().min(1, "Department name is required"),
-    }),
+  body: z.object({
+    name: z.string().min(1, 'Department name is required')
+  })
 });
 
 export const updateDepartmentSchema = z.object({
-    params: idParam,
-    body: z.object({
-        name: z.string().min(1, "Department name is required"),
-    }),
+  params: idParam,
+  body: z.object({
+    name: z.string().min(1, 'Department name is required')
+  })
 });

--- a/backend/src/modules/leave/leave-router.ts
+++ b/backend/src/modules/leave/leave-router.ts
@@ -1,17 +1,28 @@
 import { Router } from 'express';
 import * as leaveController from './leave-controller';
 import { checkApiAccess } from '../../middlewares';
+import { validateRequest } from '../../utils';
+import {
+  addLeaveRequestSchema,
+  updateLeaveRequestSchema,
+  leaveIdParamSchema,
+  addLeavePolicySchema,
+  updateLeavePolicySchema,
+  reviewLeaveStatusSchema,
+  policyUsersSchema,
+  removePolicyUserSchema
+} from './leave-schema';
 
 const router = Router();
 
-router.post('/policies', checkApiAccess, leaveController.handleMakeNewPolicy);
+router.post('/policies', checkApiAccess, validateRequest(addLeavePolicySchema), leaveController.handleMakeNewPolicy);
 router.get('/policies', checkApiAccess, leaveController.handleGetLeavePolicies);
 router.get('/policies/me', checkApiAccess, leaveController.handleGetMyLeavePolicy);
-router.put('/policies/:id', checkApiAccess, leaveController.handleUpdateLeavePlicy);
-router.post('/policies/:id/status', checkApiAccess, leaveController.handleReviewLeavePolicy);
-router.post('/policies/:id/users', checkApiAccess, leaveController.handleUpdatePolicyUsers);
-router.get('/policies/:id/users', checkApiAccess, leaveController.handleGetPolicyUsers);
-router.delete('/policies/:id/users', checkApiAccess, leaveController.handleRemovePolicyUser);
+router.put('/policies/:id', checkApiAccess, validateRequest(updateLeavePolicySchema), leaveController.handleUpdateLeavePlicy);
+router.post('/policies/:id/status', checkApiAccess, validateRequest(reviewLeaveStatusSchema), leaveController.handleReviewLeavePolicy);
+router.post('/policies/:id/users', checkApiAccess, validateRequest(policyUsersSchema), leaveController.handleUpdatePolicyUsers);
+router.get('/policies/:id/users', checkApiAccess, validateRequest(leaveIdParamSchema), leaveController.handleGetPolicyUsers);
+router.delete('/policies/:id/users', checkApiAccess, validateRequest(removePolicyUserSchema), leaveController.handleRemovePolicyUser);
 router.get(
   '/policies/eligible-users',
   checkApiAccess,
@@ -19,11 +30,11 @@ router.get(
 );
 
 router.get('/request', checkApiAccess, leaveController.handleGetUserLeaveHistory);
-router.post('/request', checkApiAccess, leaveController.handleCreateNewLeaveRequest);
-router.put('/request/:id', checkApiAccess, leaveController.handleUpdateLeaveRequest);
-router.delete('/request/:id', checkApiAccess, leaveController.handleDeleteLeaveRequest);
+router.post('/request', checkApiAccess, validateRequest(addLeaveRequestSchema), leaveController.handleCreateNewLeaveRequest);
+router.put('/request/:id', checkApiAccess, validateRequest(updateLeaveRequestSchema), leaveController.handleUpdateLeaveRequest);
+router.delete('/request/:id', checkApiAccess, validateRequest(leaveIdParamSchema), leaveController.handleDeleteLeaveRequest);
 
 router.get('/pending', checkApiAccess, leaveController.handleFetchPendingLeaveRequests);
-router.post('/pending/:id/status', checkApiAccess, leaveController.handleReviewLeaveRequest);
+router.post('/pending/:id/status', checkApiAccess, validateRequest(reviewLeaveStatusSchema), leaveController.handleReviewLeaveRequest);
 
 export { router as leaveRoutes };

--- a/backend/src/modules/leave/leave-router.ts
+++ b/backend/src/modules/leave/leave-router.ts
@@ -15,14 +15,44 @@ import {
 
 const router = Router();
 
-router.post('/policies', checkApiAccess, validateRequest(addLeavePolicySchema), leaveController.handleMakeNewPolicy);
+router.post(
+  '/policies',
+  checkApiAccess,
+  validateRequest(addLeavePolicySchema),
+  leaveController.handleMakeNewPolicy
+);
 router.get('/policies', checkApiAccess, leaveController.handleGetLeavePolicies);
 router.get('/policies/me', checkApiAccess, leaveController.handleGetMyLeavePolicy);
-router.put('/policies/:id', checkApiAccess, validateRequest(updateLeavePolicySchema), leaveController.handleUpdateLeavePlicy);
-router.post('/policies/:id/status', checkApiAccess, validateRequest(reviewLeaveStatusSchema), leaveController.handleReviewLeavePolicy);
-router.post('/policies/:id/users', checkApiAccess, validateRequest(policyUsersSchema), leaveController.handleUpdatePolicyUsers);
-router.get('/policies/:id/users', checkApiAccess, validateRequest(leaveIdParamSchema), leaveController.handleGetPolicyUsers);
-router.delete('/policies/:id/users', checkApiAccess, validateRequest(removePolicyUserSchema), leaveController.handleRemovePolicyUser);
+router.put(
+  '/policies/:id',
+  checkApiAccess,
+  validateRequest(updateLeavePolicySchema),
+  leaveController.handleUpdateLeavePlicy
+);
+router.post(
+  '/policies/:id/status',
+  checkApiAccess,
+  validateRequest(reviewLeaveStatusSchema),
+  leaveController.handleReviewLeavePolicy
+);
+router.post(
+  '/policies/:id/users',
+  checkApiAccess,
+  validateRequest(policyUsersSchema),
+  leaveController.handleUpdatePolicyUsers
+);
+router.get(
+  '/policies/:id/users',
+  checkApiAccess,
+  validateRequest(leaveIdParamSchema),
+  leaveController.handleGetPolicyUsers
+);
+router.delete(
+  '/policies/:id/users',
+  checkApiAccess,
+  validateRequest(removePolicyUserSchema),
+  leaveController.handleRemovePolicyUser
+);
 router.get(
   '/policies/eligible-users',
   checkApiAccess,
@@ -30,11 +60,31 @@ router.get(
 );
 
 router.get('/request', checkApiAccess, leaveController.handleGetUserLeaveHistory);
-router.post('/request', checkApiAccess, validateRequest(addLeaveRequestSchema), leaveController.handleCreateNewLeaveRequest);
-router.put('/request/:id', checkApiAccess, validateRequest(updateLeaveRequestSchema), leaveController.handleUpdateLeaveRequest);
-router.delete('/request/:id', checkApiAccess, validateRequest(leaveIdParamSchema), leaveController.handleDeleteLeaveRequest);
+router.post(
+  '/request',
+  checkApiAccess,
+  validateRequest(addLeaveRequestSchema),
+  leaveController.handleCreateNewLeaveRequest
+);
+router.put(
+  '/request/:id',
+  checkApiAccess,
+  validateRequest(updateLeaveRequestSchema),
+  leaveController.handleUpdateLeaveRequest
+);
+router.delete(
+  '/request/:id',
+  checkApiAccess,
+  validateRequest(leaveIdParamSchema),
+  leaveController.handleDeleteLeaveRequest
+);
 
 router.get('/pending', checkApiAccess, leaveController.handleFetchPendingLeaveRequests);
-router.post('/pending/:id/status', checkApiAccess, validateRequest(reviewLeaveStatusSchema), leaveController.handleReviewLeaveRequest);
+router.post(
+  '/pending/:id/status',
+  checkApiAccess,
+  validateRequest(reviewLeaveStatusSchema),
+  leaveController.handleReviewLeaveRequest
+);
 
 export { router as leaveRoutes };

--- a/backend/src/modules/leave/leave-schema.ts
+++ b/backend/src/modules/leave/leave-schema.ts
@@ -1,62 +1,62 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 const idParam = z.object({
-    id: z.string().regex(/^\d+$/, "ID must be a number"),
+  id: z.string().regex(/^\d+$/, 'ID must be a number')
 });
 
 export const addLeaveRequestSchema = z.object({
-    body: z.object({
-        policy: z.number().min(1, "Policy is required"),
-        from: z.string().min(1, "From date is required"),
-        to: z.string().min(1, "To date is required"),
-        note: z.string().min(1, "Note is required"),
-    }),
+  body: z.object({
+    policy: z.number().min(1, 'Policy is required'),
+    from: z.string().min(1, 'From date is required'),
+    to: z.string().min(1, 'To date is required'),
+    note: z.string().min(1, 'Note is required')
+  })
 });
 
 export const updateLeaveRequestSchema = z.object({
-    params: idParam,
-    body: z.object({
-        policy: z.number().min(1, "Policy is required"),
-        from: z.string().min(1, "From date is required"),
-        to: z.string().min(1, "To date is required"),
-        note: z.string().min(1, "Note is required"),
-    }),
+  params: idParam,
+  body: z.object({
+    policy: z.number().min(1, 'Policy is required'),
+    from: z.string().min(1, 'From date is required'),
+    to: z.string().min(1, 'To date is required'),
+    note: z.string().min(1, 'Note is required')
+  })
 });
 
 export const leaveIdParamSchema = z.object({
-    params: idParam,
+  params: idParam
 });
 
 export const addLeavePolicySchema = z.object({
-    body: z.object({
-        name: z.string().min(1, "Policy name is required"),
-    }),
+  body: z.object({
+    name: z.string().min(1, 'Policy name is required')
+  })
 });
 
 export const updateLeavePolicySchema = z.object({
-    params: idParam,
-    body: z.object({
-        name: z.string().min(1, "Policy name is required"),
-    }),
+  params: idParam,
+  body: z.object({
+    name: z.string().min(1, 'Policy name is required')
+  })
 });
 
 export const reviewLeaveStatusSchema = z.object({
-    params: idParam,
-    body: z.object({
-        status: z.number({ required_error: "Status is required" }),
-    }),
+  params: idParam,
+  body: z.object({
+    status: z.number({ required_error: 'Status is required' })
+  })
 });
 
 export const policyUsersSchema = z.object({
-    params: idParam,
-    body: z.object({
-        users: z.array(z.number()).min(1, "You must select at least one user"),
-    }),
+  params: idParam,
+  body: z.object({
+    users: z.array(z.number()).min(1, 'You must select at least one user')
+  })
 });
 
 export const removePolicyUserSchema = z.object({
-    params: idParam,
-    body: z.object({
-        user: z.number({ required_error: "User is required" }),
-    }),
+  params: idParam,
+  body: z.object({
+    user: z.number({ required_error: 'User is required' })
+  })
 });

--- a/backend/src/modules/leave/leave-schema.ts
+++ b/backend/src/modules/leave/leave-schema.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+const idParam = z.object({
+    id: z.string().regex(/^\d+$/, "ID must be a number"),
+});
+
+export const addLeaveRequestSchema = z.object({
+    body: z.object({
+        policy: z.number().min(1, "Policy is required"),
+        from: z.string().min(1, "From date is required"),
+        to: z.string().min(1, "To date is required"),
+        note: z.string().min(1, "Note is required"),
+    }),
+});
+
+export const updateLeaveRequestSchema = z.object({
+    params: idParam,
+    body: z.object({
+        policy: z.number().min(1, "Policy is required"),
+        from: z.string().min(1, "From date is required"),
+        to: z.string().min(1, "To date is required"),
+        note: z.string().min(1, "Note is required"),
+    }),
+});
+
+export const leaveIdParamSchema = z.object({
+    params: idParam,
+});
+
+export const addLeavePolicySchema = z.object({
+    body: z.object({
+        name: z.string().min(1, "Policy name is required"),
+    }),
+});
+
+export const updateLeavePolicySchema = z.object({
+    params: idParam,
+    body: z.object({
+        name: z.string().min(1, "Policy name is required"),
+    }),
+});
+
+export const reviewLeaveStatusSchema = z.object({
+    params: idParam,
+    body: z.object({
+        status: z.number({ required_error: "Status is required" }),
+    }),
+});
+
+export const policyUsersSchema = z.object({
+    params: idParam,
+    body: z.object({
+        users: z.array(z.number()).min(1, "You must select at least one user"),
+    }),
+});
+
+export const removePolicyUserSchema = z.object({
+    params: idParam,
+    body: z.object({
+        user: z.number({ required_error: "User is required" }),
+    }),
+});

--- a/backend/src/modules/notices/notices-repository.ts
+++ b/backend/src/modules/notices/notices-repository.ts
@@ -168,7 +168,6 @@ const getNoticeRecipients = async (): Promise<any[]> => {
             t1.id,
             t1.role_id AS "roleId",
             t1.primary_dependent_name AS "primaryDependentName",
-            t1.primary_dependent_select AS "primaryDependentSelect",
             t2.name as "roleName"
         FROM notice_recipient_types t1
         JOIN roles t2 ON t1.role_id = t2.id

--- a/backend/src/modules/notices/notices-router.ts
+++ b/backend/src/modules/notices/notices-router.ts
@@ -1,20 +1,29 @@
 import { Router } from 'express';
 import * as noticeController from './notices-controller';
 import { checkApiAccess } from '../../middlewares';
+import { validateRequest } from '../../utils';
+import {
+  addNoticeSchema,
+  updateNoticeSchema,
+  noticeIdParamSchema,
+  noticeStatusSchema,
+  addNoticeRecipientSchema,
+  updateNoticeRecipientSchema
+} from './notices-schema';
 
 const router = Router();
 
 router.get('/recipients/list', checkApiAccess, noticeController.handleFetchNoticeRecipients);
 router.get('/recipients', checkApiAccess, noticeController.handleGetNoticeRecipients);
-router.get('/recipients/:id', checkApiAccess, noticeController.handleGetNoticeRecipient);
-router.post('/recipients', checkApiAccess, noticeController.handleAddNoticeRecipient);
-router.put('/recipients/:id', checkApiAccess, noticeController.handleUpdateNoticeRecipient);
-router.delete('/recipients/:id', checkApiAccess, noticeController.handleDeleteNoticeRecipient);
-router.post('/:id/status', checkApiAccess, noticeController.handleNoticeStatus);
+router.get('/recipients/:id', checkApiAccess, validateRequest(noticeIdParamSchema), noticeController.handleGetNoticeRecipient);
+router.post('/recipients', checkApiAccess, validateRequest(addNoticeRecipientSchema), noticeController.handleAddNoticeRecipient);
+router.put('/recipients/:id', checkApiAccess, validateRequest(updateNoticeRecipientSchema), noticeController.handleUpdateNoticeRecipient);
+router.delete('/recipients/:id', checkApiAccess, validateRequest(noticeIdParamSchema), noticeController.handleDeleteNoticeRecipient);
+router.post('/:id/status', checkApiAccess, validateRequest(noticeStatusSchema), noticeController.handleNoticeStatus);
 router.get('/pending', checkApiAccess, noticeController.handleFetchAllPendingNotices);
-router.get('/:id', checkApiAccess, noticeController.handleFetchNoticeDetailById);
+router.get('/:id', checkApiAccess, validateRequest(noticeIdParamSchema), noticeController.handleFetchNoticeDetailById);
 router.get('', checkApiAccess, noticeController.handleFetchAllNotices);
-router.post('', checkApiAccess, noticeController.handleAddNotice);
-router.put('/:id', checkApiAccess, noticeController.handleUpdateNotice);
+router.post('', checkApiAccess, validateRequest(addNoticeSchema), noticeController.handleAddNotice);
+router.put('/:id', checkApiAccess, validateRequest(updateNoticeSchema), noticeController.handleUpdateNotice);
 
 export { router as noticesRoutes };

--- a/backend/src/modules/notices/notices-router.ts
+++ b/backend/src/modules/notices/notices-router.ts
@@ -15,15 +15,50 @@ const router = Router();
 
 router.get('/recipients/list', checkApiAccess, noticeController.handleFetchNoticeRecipients);
 router.get('/recipients', checkApiAccess, noticeController.handleGetNoticeRecipients);
-router.get('/recipients/:id', checkApiAccess, validateRequest(noticeIdParamSchema), noticeController.handleGetNoticeRecipient);
-router.post('/recipients', checkApiAccess, validateRequest(addNoticeRecipientSchema), noticeController.handleAddNoticeRecipient);
-router.put('/recipients/:id', checkApiAccess, validateRequest(updateNoticeRecipientSchema), noticeController.handleUpdateNoticeRecipient);
-router.delete('/recipients/:id', checkApiAccess, validateRequest(noticeIdParamSchema), noticeController.handleDeleteNoticeRecipient);
-router.post('/:id/status', checkApiAccess, validateRequest(noticeStatusSchema), noticeController.handleNoticeStatus);
+router.get(
+  '/recipients/:id',
+  checkApiAccess,
+  validateRequest(noticeIdParamSchema),
+  noticeController.handleGetNoticeRecipient
+);
+router.post(
+  '/recipients',
+  checkApiAccess,
+  validateRequest(addNoticeRecipientSchema),
+  noticeController.handleAddNoticeRecipient
+);
+router.put(
+  '/recipients/:id',
+  checkApiAccess,
+  validateRequest(updateNoticeRecipientSchema),
+  noticeController.handleUpdateNoticeRecipient
+);
+router.delete(
+  '/recipients/:id',
+  checkApiAccess,
+  validateRequest(noticeIdParamSchema),
+  noticeController.handleDeleteNoticeRecipient
+);
+router.post(
+  '/:id/status',
+  checkApiAccess,
+  validateRequest(noticeStatusSchema),
+  noticeController.handleNoticeStatus
+);
 router.get('/pending', checkApiAccess, noticeController.handleFetchAllPendingNotices);
-router.get('/:id', checkApiAccess, validateRequest(noticeIdParamSchema), noticeController.handleFetchNoticeDetailById);
+router.get(
+  '/:id',
+  checkApiAccess,
+  validateRequest(noticeIdParamSchema),
+  noticeController.handleFetchNoticeDetailById
+);
 router.get('', checkApiAccess, noticeController.handleFetchAllNotices);
 router.post('', checkApiAccess, validateRequest(addNoticeSchema), noticeController.handleAddNotice);
-router.put('/:id', checkApiAccess, validateRequest(updateNoticeSchema), noticeController.handleUpdateNotice);
+router.put(
+  '/:id',
+  checkApiAccess,
+  validateRequest(updateNoticeSchema),
+  noticeController.handleUpdateNotice
+);
 
 export { router as noticesRoutes };

--- a/backend/src/modules/notices/notices-schema.ts
+++ b/backend/src/modules/notices/notices-schema.ts
@@ -1,51 +1,51 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 const idParam = z.object({
-    id: z.string().regex(/^\d+$/, "ID must be a number"),
+  id: z.string().regex(/^\d+$/, 'ID must be a number')
 });
 
 const noticeBodyFields = {
-    title: z.string().min(1, "Title is required"),
-    description: z.string().min(1, "Description is required"),
-    status: z.number().min(1, "Status is required"),
-    recipientType: z.enum(["EV", "SP"]),
-    recipientRole: z.number().optional(),
-    firstField: z.union([z.number(), z.string()]).optional(),
+  title: z.string().min(1, 'Title is required'),
+  description: z.string().min(1, 'Description is required'),
+  status: z.number().min(1, 'Status is required'),
+  recipientType: z.enum(['EV', 'SP']),
+  recipientRole: z.number().optional(),
+  firstField: z.union([z.number(), z.string()]).optional()
 };
 
 export const addNoticeSchema = z.object({
-    body: z.object(noticeBodyFields),
+  body: z.object(noticeBodyFields)
 });
 
 export const updateNoticeSchema = z.object({
-    params: idParam,
-    body: z.object(noticeBodyFields),
+  params: idParam,
+  body: z.object(noticeBodyFields)
 });
 
 export const noticeIdParamSchema = z.object({
-    params: idParam,
+  params: idParam
 });
 
 export const noticeStatusSchema = z.object({
-    params: idParam,
-    body: z.object({
-        status: z.number({ required_error: "Status is required" }),
-    }),
+  params: idParam,
+  body: z.object({
+    status: z.number({ required_error: 'Status is required' })
+  })
 });
 
 export const addNoticeRecipientSchema = z.object({
-    body: z.object({
-        roleId: z.number().min(1, "Role is required"),
-        primaryDependentName: z.string().min(1, "Name is required"),
-        primaryDependentSelect: z.string().min(1, "Select statement is required"),
-    }),
+  body: z.object({
+    roleId: z.number().min(1, 'Role is required'),
+    primaryDependentName: z.string().min(1, 'Name is required'),
+    primaryDependentSelect: z.string().min(1, 'Select statement is required')
+  })
 });
 
 export const updateNoticeRecipientSchema = z.object({
-    params: idParam,
-    body: z.object({
-        roleId: z.number().min(1, "Role is required"),
-        primaryDependentName: z.string().min(1, "Name is required"),
-        primaryDependentSelect: z.string().min(1, "Select statement is required"),
-    }),
+  params: idParam,
+  body: z.object({
+    roleId: z.number().min(1, 'Role is required'),
+    primaryDependentName: z.string().min(1, 'Name is required'),
+    primaryDependentSelect: z.string().min(1, 'Select statement is required')
+  })
 });

--- a/backend/src/modules/notices/notices-schema.ts
+++ b/backend/src/modules/notices/notices-schema.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+const idParam = z.object({
+    id: z.string().regex(/^\d+$/, "ID must be a number"),
+});
+
+const noticeBodyFields = {
+    title: z.string().min(1, "Title is required"),
+    description: z.string().min(1, "Description is required"),
+    status: z.number().min(1, "Status is required"),
+    recipientType: z.enum(["EV", "SP"]),
+    recipientRole: z.number().optional(),
+    firstField: z.union([z.number(), z.string()]).optional(),
+};
+
+export const addNoticeSchema = z.object({
+    body: z.object(noticeBodyFields),
+});
+
+export const updateNoticeSchema = z.object({
+    params: idParam,
+    body: z.object(noticeBodyFields),
+});
+
+export const noticeIdParamSchema = z.object({
+    params: idParam,
+});
+
+export const noticeStatusSchema = z.object({
+    params: idParam,
+    body: z.object({
+        status: z.number({ required_error: "Status is required" }),
+    }),
+});
+
+export const addNoticeRecipientSchema = z.object({
+    body: z.object({
+        roleId: z.number().min(1, "Role is required"),
+        primaryDependentName: z.string().min(1, "Name is required"),
+        primaryDependentSelect: z.string().min(1, "Select statement is required"),
+    }),
+});
+
+export const updateNoticeRecipientSchema = z.object({
+    params: idParam,
+    body: z.object({
+        roleId: z.number().min(1, "Role is required"),
+        primaryDependentName: z.string().min(1, "Name is required"),
+        primaryDependentSelect: z.string().min(1, "Select statement is required"),
+    }),
+});

--- a/backend/src/modules/roles-and-permissions/rp-router.ts
+++ b/backend/src/modules/roles-and-permissions/rp-router.ts
@@ -1,16 +1,25 @@
 import { Router } from 'express';
 import * as rpController from './rp-controller';
+import { validateRequest } from '../../utils';
+import {
+    roleIdParamSchema,
+    addRoleSchema,
+    updateRoleSchema,
+    roleStatusSchema,
+    rolePermissionsSchema,
+    switchRoleSchema,
+} from './rp-schema';
 
 const router = Router();
 
 router.get('', rpController.handleGetRoles);
-router.post('', rpController.handleAddRole);
-router.post('/switch', rpController.handleSwitchRole);
-router.put('/:id', rpController.handleUpdateRole);
-router.post('/:id/status', rpController.handleRoleStatus);
-router.get('/:id', rpController.handleGetRole);
-router.get('/:id/permissions', rpController.handleGetRolePermission);
-router.post('/:id/permissions', rpController.handleAddRolePermission);
-router.get('/:id/users', rpController.handleGetUsersByRoleId);
+router.post('', validateRequest(addRoleSchema), rpController.handleAddRole);
+router.post('/switch', validateRequest(switchRoleSchema), rpController.handleSwitchRole);
+router.put('/:id', validateRequest(updateRoleSchema), rpController.handleUpdateRole);
+router.post('/:id/status', validateRequest(roleStatusSchema), rpController.handleRoleStatus);
+router.get('/:id', validateRequest(roleIdParamSchema), rpController.handleGetRole);
+router.get('/:id/permissions', validateRequest(roleIdParamSchema), rpController.handleGetRolePermission);
+router.post('/:id/permissions', validateRequest(rolePermissionsSchema), rpController.handleAddRolePermission);
+router.get('/:id/users', validateRequest(roleIdParamSchema), rpController.handleGetUsersByRoleId);
 
 export { router as rpRoutes };

--- a/backend/src/modules/roles-and-permissions/rp-router.ts
+++ b/backend/src/modules/roles-and-permissions/rp-router.ts
@@ -2,12 +2,12 @@ import { Router } from 'express';
 import * as rpController from './rp-controller';
 import { validateRequest } from '../../utils';
 import {
-    roleIdParamSchema,
-    addRoleSchema,
-    updateRoleSchema,
-    roleStatusSchema,
-    rolePermissionsSchema,
-    switchRoleSchema,
+  roleIdParamSchema,
+  addRoleSchema,
+  updateRoleSchema,
+  roleStatusSchema,
+  rolePermissionsSchema,
+  switchRoleSchema
 } from './rp-schema';
 
 const router = Router();
@@ -18,8 +18,16 @@ router.post('/switch', validateRequest(switchRoleSchema), rpController.handleSwi
 router.put('/:id', validateRequest(updateRoleSchema), rpController.handleUpdateRole);
 router.post('/:id/status', validateRequest(roleStatusSchema), rpController.handleRoleStatus);
 router.get('/:id', validateRequest(roleIdParamSchema), rpController.handleGetRole);
-router.get('/:id/permissions', validateRequest(roleIdParamSchema), rpController.handleGetRolePermission);
-router.post('/:id/permissions', validateRequest(rolePermissionsSchema), rpController.handleAddRolePermission);
+router.get(
+  '/:id/permissions',
+  validateRequest(roleIdParamSchema),
+  rpController.handleGetRolePermission
+);
+router.post(
+  '/:id/permissions',
+  validateRequest(rolePermissionsSchema),
+  rpController.handleAddRolePermission
+);
 router.get('/:id/users', validateRequest(roleIdParamSchema), rpController.handleGetUsersByRoleId);
 
 export { router as rpRoutes };

--- a/backend/src/modules/roles-and-permissions/rp-schema.ts
+++ b/backend/src/modules/roles-and-permissions/rp-schema.ts
@@ -1,43 +1,43 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 const idParam = z.object({
-    id: z.string().regex(/^\d+$/, "ID must be a number"),
+  id: z.string().regex(/^\d+$/, 'ID must be a number')
 });
 
 export const roleIdParamSchema = z.object({
-    params: idParam,
+  params: idParam
 });
 
 export const addRoleSchema = z.object({
-    body: z.object({
-        name: z.string().min(1, "Role name is required"),
-    }),
+  body: z.object({
+    name: z.string().min(1, 'Role name is required')
+  })
 });
 
 export const updateRoleSchema = z.object({
-    params: idParam,
-    body: z.object({
-        name: z.string().min(1, "Role name is required"),
-    }),
+  params: idParam,
+  body: z.object({
+    name: z.string().min(1, 'Role name is required')
+  })
 });
 
 export const roleStatusSchema = z.object({
-    params: idParam,
-    body: z.object({
-        status: z.boolean({ required_error: "Status is required" }),
-    }),
+  params: idParam,
+  body: z.object({
+    status: z.boolean({ required_error: 'Status is required' })
+  })
 });
 
 export const rolePermissionsSchema = z.object({
-    params: idParam,
-    body: z.object({
-        permissions: z.array(z.number()).min(1, "At least one permission is required"),
-    }),
+  params: idParam,
+  body: z.object({
+    permissions: z.array(z.number()).min(1, 'At least one permission is required')
+  })
 });
 
 export const switchRoleSchema = z.object({
-    body: z.object({
-        userId: z.number({ required_error: "User ID is required" }),
-        roleId: z.number({ required_error: "Role ID is required" }),
-    }),
+  body: z.object({
+    userId: z.number({ required_error: 'User ID is required' }),
+    roleId: z.number({ required_error: 'Role ID is required' })
+  })
 });

--- a/backend/src/modules/roles-and-permissions/rp-schema.ts
+++ b/backend/src/modules/roles-and-permissions/rp-schema.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+const idParam = z.object({
+    id: z.string().regex(/^\d+$/, "ID must be a number"),
+});
+
+export const roleIdParamSchema = z.object({
+    params: idParam,
+});
+
+export const addRoleSchema = z.object({
+    body: z.object({
+        name: z.string().min(1, "Role name is required"),
+    }),
+});
+
+export const updateRoleSchema = z.object({
+    params: idParam,
+    body: z.object({
+        name: z.string().min(1, "Role name is required"),
+    }),
+});
+
+export const roleStatusSchema = z.object({
+    params: idParam,
+    body: z.object({
+        status: z.boolean({ required_error: "Status is required" }),
+    }),
+});
+
+export const rolePermissionsSchema = z.object({
+    params: idParam,
+    body: z.object({
+        permissions: z.array(z.number()).min(1, "At least one permission is required"),
+    }),
+});
+
+export const switchRoleSchema = z.object({
+    body: z.object({
+        userId: z.number({ required_error: "User ID is required" }),
+        roleId: z.number({ required_error: "Role ID is required" }),
+    }),
+});

--- a/backend/src/modules/sections/section-router.ts
+++ b/backend/src/modules/sections/section-router.ts
@@ -9,6 +9,10 @@ router.get('', sectionController.handleGetAllSections);
 router.post('', validateRequest(addSectionSchema), sectionController.handleAddNewSection);
 router.get('/:id', validateRequest(sectionIdParamSchema), sectionController.handleGetSectionById);
 router.put('/:id', validateRequest(updateSectionSchema), sectionController.handleUpdateSectionById);
-router.delete('/:id', validateRequest(sectionIdParamSchema), sectionController.handleDeleteSectionById);
+router.delete(
+  '/:id',
+  validateRequest(sectionIdParamSchema),
+  sectionController.handleDeleteSectionById
+);
 
 export { router as sectionRoutes };

--- a/backend/src/modules/sections/section-router.ts
+++ b/backend/src/modules/sections/section-router.ts
@@ -1,12 +1,14 @@
 import { Router } from 'express';
 import * as sectionController from './section-controller';
+import { validateRequest } from '../../utils';
+import { sectionIdParamSchema, addSectionSchema, updateSectionSchema } from './section-schema';
 
 const router = Router();
 
 router.get('', sectionController.handleGetAllSections);
-router.post('', sectionController.handleAddNewSection);
-router.get('/:id', sectionController.handleGetSectionById);
-router.put('/:id', sectionController.handleUpdateSectionById);
-router.delete('/:id', sectionController.handleDeleteSectionById);
+router.post('', validateRequest(addSectionSchema), sectionController.handleAddNewSection);
+router.get('/:id', validateRequest(sectionIdParamSchema), sectionController.handleGetSectionById);
+router.put('/:id', validateRequest(updateSectionSchema), sectionController.handleUpdateSectionById);
+router.delete('/:id', validateRequest(sectionIdParamSchema), sectionController.handleDeleteSectionById);
 
 export { router as sectionRoutes };

--- a/backend/src/modules/sections/section-schema.ts
+++ b/backend/src/modules/sections/section-schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+const idParam = z.object({
+    id: z.string().regex(/^\d+$/, "ID must be a number"),
+});
+
+export const sectionIdParamSchema = z.object({
+    params: idParam,
+});
+
+export const addSectionSchema = z.object({
+    body: z.object({
+        name: z.string().min(1, "Section name is required"),
+    }),
+});
+
+export const updateSectionSchema = z.object({
+    params: idParam,
+    body: z.object({
+        name: z.string().min(1, "Section name is required"),
+    }),
+});

--- a/backend/src/modules/sections/section-schema.ts
+++ b/backend/src/modules/sections/section-schema.ts
@@ -1,22 +1,22 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 const idParam = z.object({
-    id: z.string().regex(/^\d+$/, "ID must be a number"),
+  id: z.string().regex(/^\d+$/, 'ID must be a number')
 });
 
 export const sectionIdParamSchema = z.object({
-    params: idParam,
+  params: idParam
 });
 
 export const addSectionSchema = z.object({
-    body: z.object({
-        name: z.string().min(1, "Section name is required"),
-    }),
+  body: z.object({
+    name: z.string().min(1, 'Section name is required')
+  })
 });
 
 export const updateSectionSchema = z.object({
-    params: idParam,
-    body: z.object({
-        name: z.string().min(1, "Section name is required"),
-    }),
+  params: idParam,
+  body: z.object({
+    name: z.string().min(1, 'Section name is required')
+  })
 });

--- a/backend/src/modules/staffs/staffs-router.ts
+++ b/backend/src/modules/staffs/staffs-router.ts
@@ -1,12 +1,20 @@
 import { Router } from 'express';
 import * as staffsController from './staffs-controller';
+import { validateRequest } from '../../utils';
+import {
+  getStaffsSchema,
+  staffIdParamSchema,
+  addStaffSchema,
+  updateStaffSchema,
+  staffStatusSchema
+} from './staffs-schema';
 
 const router = Router();
 
-router.get('', staffsController.handleGetAllStaffs);
-router.post('', staffsController.handleAddStaff);
-router.get('/:id', staffsController.handleGetStaff);
-router.put('/:id', staffsController.handleUpdateStaff);
-router.post('/:id/status', staffsController.handleReviewStaffStatus);
+router.get('', validateRequest(getStaffsSchema), staffsController.handleGetAllStaffs);
+router.post('', validateRequest(addStaffSchema), staffsController.handleAddStaff);
+router.get('/:id', validateRequest(staffIdParamSchema), staffsController.handleGetStaff);
+router.put('/:id', validateRequest(updateStaffSchema), staffsController.handleUpdateStaff);
+router.post('/:id/status', validateRequest(staffStatusSchema), staffsController.handleReviewStaffStatus);
 
 export { router as staffsRoutes };

--- a/backend/src/modules/staffs/staffs-router.ts
+++ b/backend/src/modules/staffs/staffs-router.ts
@@ -15,6 +15,10 @@ router.get('', validateRequest(getStaffsSchema), staffsController.handleGetAllSt
 router.post('', validateRequest(addStaffSchema), staffsController.handleAddStaff);
 router.get('/:id', validateRequest(staffIdParamSchema), staffsController.handleGetStaff);
 router.put('/:id', validateRequest(updateStaffSchema), staffsController.handleUpdateStaff);
-router.post('/:id/status', validateRequest(staffStatusSchema), staffsController.handleReviewStaffStatus);
+router.post(
+  '/:id/status',
+  validateRequest(staffStatusSchema),
+  staffsController.handleReviewStaffStatus
+);
 
 export { router as staffsRoutes };

--- a/backend/src/modules/staffs/staffs-schema.ts
+++ b/backend/src/modules/staffs/staffs-schema.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+const idParam = z.object({
+    id: z.string().regex(/^\d+$/, "ID must be a number"),
+});
+
+const staffBodyFields = {
+    name: z.string().min(1, "Name is required"),
+    role: z.number().min(1, "Role is required"),
+    gender: z.string().min(1, "Gender is required"),
+    maritalStatus: z.string().min(1, "Marital status is required"),
+    phone: z.string().min(1, "Phone is required"),
+    email: z.string().email("Invalid email address"),
+    dob: z.string().optional(),
+    joinDate: z.string().optional(),
+    qualification: z.string().optional(),
+    experience: z.string().optional(),
+    currentAddress: z.string().optional(),
+    permanentAddress: z.string().optional(),
+    fatherName: z.string().optional(),
+    motherName: z.string().optional(),
+    emergencyPhone: z.string().optional(),
+    systemAccess: z.boolean().optional(),
+    reporterId: z.number().optional(),
+};
+
+export const getStaffsSchema = z.object({
+    query: z.object({
+        userId: z.string().optional(),
+        roleId: z.string().optional(),
+        name: z.string().optional(),
+    }),
+});
+
+export const staffIdParamSchema = z.object({
+    params: idParam,
+});
+
+export const addStaffSchema = z.object({
+    body: z.object(staffBodyFields),
+});
+
+export const updateStaffSchema = z.object({
+    params: idParam,
+    body: z.object(staffBodyFields).partial(),
+});
+
+export const staffStatusSchema = z.object({
+    params: idParam,
+    body: z.object({
+        status: z.boolean({ required_error: "Status is required" }),
+    }),
+});

--- a/backend/src/modules/staffs/staffs-schema.ts
+++ b/backend/src/modules/staffs/staffs-schema.ts
@@ -1,53 +1,53 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 const idParam = z.object({
-    id: z.string().regex(/^\d+$/, "ID must be a number"),
+  id: z.string().regex(/^\d+$/, 'ID must be a number')
 });
 
 const staffBodyFields = {
-    name: z.string().min(1, "Name is required"),
-    role: z.number().min(1, "Role is required"),
-    gender: z.string().min(1, "Gender is required"),
-    maritalStatus: z.string().min(1, "Marital status is required"),
-    phone: z.string().min(1, "Phone is required"),
-    email: z.string().email("Invalid email address"),
-    dob: z.string().optional(),
-    joinDate: z.string().optional(),
-    qualification: z.string().optional(),
-    experience: z.string().optional(),
-    currentAddress: z.string().optional(),
-    permanentAddress: z.string().optional(),
-    fatherName: z.string().optional(),
-    motherName: z.string().optional(),
-    emergencyPhone: z.string().optional(),
-    systemAccess: z.boolean().optional(),
-    reporterId: z.number().optional(),
+  name: z.string().min(1, 'Name is required'),
+  role: z.number().min(1, 'Role is required'),
+  gender: z.string().min(1, 'Gender is required'),
+  maritalStatus: z.string().min(1, 'Marital status is required'),
+  phone: z.string().min(1, 'Phone is required'),
+  email: z.string().email('Invalid email address'),
+  dob: z.string().optional(),
+  joinDate: z.string().optional(),
+  qualification: z.string().optional(),
+  experience: z.string().optional(),
+  currentAddress: z.string().optional(),
+  permanentAddress: z.string().optional(),
+  fatherName: z.string().optional(),
+  motherName: z.string().optional(),
+  emergencyPhone: z.string().optional(),
+  systemAccess: z.boolean().optional(),
+  reporterId: z.number().optional()
 };
 
 export const getStaffsSchema = z.object({
-    query: z.object({
-        userId: z.string().optional(),
-        roleId: z.string().optional(),
-        name: z.string().optional(),
-    }),
+  query: z.object({
+    userId: z.string().optional(),
+    roleId: z.string().optional(),
+    name: z.string().optional()
+  })
 });
 
 export const staffIdParamSchema = z.object({
-    params: idParam,
+  params: idParam
 });
 
 export const addStaffSchema = z.object({
-    body: z.object(staffBodyFields),
+  body: z.object(staffBodyFields)
 });
 
 export const updateStaffSchema = z.object({
-    params: idParam,
-    body: z.object(staffBodyFields).partial(),
+  params: idParam,
+  body: z.object(staffBodyFields).partial()
 });
 
 export const staffStatusSchema = z.object({
-    params: idParam,
-    body: z.object({
-        status: z.boolean({ required_error: "Status is required" }),
-    }),
+  params: idParam,
+  body: z.object({
+    status: z.boolean({ required_error: 'Status is required' })
+  })
 });

--- a/backend/src/modules/staffs/staffs-service.ts
+++ b/backend/src/modules/staffs/staffs-service.ts
@@ -44,10 +44,8 @@ const processAddStaff = async (payload: any): Promise<{ message: string }> => {
   try {
     const result = await addOrUpdateStaff(payload);
     if (!result.status) {
-      const detail = result.description
-        ? `${result.message}: ${result.description}`
-        : result.message;
-      throw new ApiError(500, detail || 'Unable to add staff');
+      if (result.description) console.error('Staff SP error:', result.description);
+      throw new ApiError(500, result.message || 'Unable to add staff');
     }
 
     try {
@@ -65,8 +63,8 @@ const processAddStaff = async (payload: any): Promise<{ message: string }> => {
 const processUpdateStaff = async (payload: any): Promise<{ message: string }> => {
   const result = await addOrUpdateStaff(payload);
   if (!result.status) {
-    const detail = result.description ? `${result.message}: ${result.description}` : result.message;
-    throw new ApiError(500, detail || 'Unable to update staff');
+    if (result.description) console.error('Staff SP error:', result.description);
+    throw new ApiError(500, result.message || 'Unable to update staff');
   }
 
   return { message: result.message };

--- a/backend/src/modules/staffs/staffs-service.ts
+++ b/backend/src/modules/staffs/staffs-service.ts
@@ -39,21 +39,25 @@ const processReviewStaffStatus = async (payload: {
 };
 
 const processAddStaff = async (payload: any): Promise<{ message: string }> => {
-  const ADD_STADD_AND_EMAIL_SEND_SUCCESS = 'Staff added and verification email sent successfully.';
+  const ADD_STAFF_AND_EMAIL_SEND_SUCCESS = 'Staff added and verification email sent successfully.';
   const ADD_STAFF_AND_BUT_EMAIL_SEND_FAIL = 'Staff added, but failed to send verification email.';
   try {
     const result = await addOrUpdateStaff(payload);
     if (!result.status) {
-      throw new ApiError(500, result.message);
+      const detail = result.description
+        ? `${result.message}: ${result.description}`
+        : result.message;
+      throw new ApiError(500, detail || 'Unable to add staff');
     }
 
     try {
       await sendAccountVerificationEmail({ userId: result.userId, userEmail: payload.email });
-      return { message: ADD_STADD_AND_EMAIL_SEND_SUCCESS };
+      return { message: ADD_STAFF_AND_EMAIL_SEND_SUCCESS };
     } catch (error) {
       return { message: ADD_STAFF_AND_BUT_EMAIL_SEND_FAIL };
     }
   } catch (error) {
+    if (error instanceof ApiError) throw error;
     throw new ApiError(500, 'Unable to add staff');
   }
 };
@@ -61,7 +65,8 @@ const processAddStaff = async (payload: any): Promise<{ message: string }> => {
 const processUpdateStaff = async (payload: any): Promise<{ message: string }> => {
   const result = await addOrUpdateStaff(payload);
   if (!result.status) {
-    throw new ApiError(500, result.message);
+    const detail = result.description ? `${result.message}: ${result.description}` : result.message;
+    throw new ApiError(500, detail || 'Unable to update staff');
   }
 
   return { message: result.message };

--- a/backend/src/modules/students/students-schema.ts
+++ b/backend/src/modules/students/students-schema.ts
@@ -10,9 +10,10 @@ const studentBodyFields = {
   phone: z.string().optional(),
   gender: z.string().optional(),
   dob: z.string().optional(),
-  className: z.string().optional(),
-  sectionName: z.string().optional(),
+  class: z.string().optional(),
+  section: z.string().optional(),
   roll: z.string().optional(),
+  admissionDate: z.string().optional(),
   fatherName: z.string().optional(),
   fatherPhone: z.string().optional(),
   motherName: z.string().optional(),
@@ -21,7 +22,8 @@ const studentBodyFields = {
   guardianPhone: z.string().optional(),
   relationOfGuardian: z.string().optional(),
   currentAddress: z.string().optional(),
-  permanentAddress: z.string().optional()
+  permanentAddress: z.string().optional(),
+  systemAccess: z.boolean().optional()
 };
 
 export const getStudentsSchema = z.object({

--- a/backend/src/modules/students/students-schema.ts
+++ b/backend/src/modules/students/students-schema.ts
@@ -12,7 +12,7 @@ const studentBodyFields = {
   dob: z.string().optional(),
   class: z.string().optional(),
   section: z.string().optional(),
-  roll: z.string().optional(),
+  roll: z.string().regex(/^\d+$/, 'Roll must be a number').optional(),
   admissionDate: z.string().optional(),
   fatherName: z.string().optional(),
   fatherPhone: z.string().optional(),

--- a/backend/src/modules/students/students-service.ts
+++ b/backend/src/modules/students/students-service.ts
@@ -48,7 +48,7 @@ const addNewStudent = async (payload: any): Promise<{ message: string }> => {
   try {
     const result = await addOrUpdateStudent(payload);
     if (!result.status) {
-      throw new ApiError(500, result.message);
+      throw new ApiError(500, result.message || 'Unable to add student');
     }
 
     try {

--- a/backend/src/modules/students/students-service.ts
+++ b/backend/src/modules/students/students-service.ts
@@ -48,10 +48,8 @@ const addNewStudent = async (payload: any): Promise<{ message: string }> => {
   try {
     const result = await addOrUpdateStudent(payload);
     if (!result.status) {
-      const detail = result.description
-        ? `${result.message}: ${result.description}`
-        : result.message;
-      throw new ApiError(500, detail || 'Unable to add student');
+      if (result.description) console.error('Student SP error:', result.description);
+      throw new ApiError(500, result.message || 'Unable to add student');
     }
 
     try {
@@ -69,8 +67,8 @@ const addNewStudent = async (payload: any): Promise<{ message: string }> => {
 const updateStudent = async (payload: any): Promise<{ message: string }> => {
   const result = await addOrUpdateStudent(payload);
   if (!result.status) {
-    const detail = result.description ? `${result.message}: ${result.description}` : result.message;
-    throw new ApiError(500, detail || 'Unable to update student');
+    if (result.description) console.error('Student SP error:', result.description);
+    throw new ApiError(500, result.message || 'Unable to update student');
   }
 
   return { message: result.message };

--- a/backend/src/modules/students/students-service.ts
+++ b/backend/src/modules/students/students-service.ts
@@ -48,7 +48,10 @@ const addNewStudent = async (payload: any): Promise<{ message: string }> => {
   try {
     const result = await addOrUpdateStudent(payload);
     if (!result.status) {
-      throw new ApiError(500, result.message || 'Unable to add student');
+      const detail = result.description
+        ? `${result.message}: ${result.description}`
+        : result.message;
+      throw new ApiError(500, detail || 'Unable to add student');
     }
 
     try {
@@ -66,7 +69,8 @@ const addNewStudent = async (payload: any): Promise<{ message: string }> => {
 const updateStudent = async (payload: any): Promise<{ message: string }> => {
   const result = await addOrUpdateStudent(payload);
   if (!result.status) {
-    throw new ApiError(500, result.message);
+    const detail = result.description ? `${result.message}: ${result.description}` : result.message;
+    throw new ApiError(500, detail || 'Unable to update student');
   }
 
   return { message: result.message };

--- a/backend/src/utils/process-db-request.ts
+++ b/backend/src/utils/process-db-request.ts
@@ -1,12 +1,34 @@
 import { QueryResult, QueryResultRow } from 'pg';
+import { DatabaseError } from 'pg';
 import { db } from '../config';
-import { ERROR_MESSAGES } from '../constants';
 import { ApiError } from './api-error';
 
 interface DBRequestParams {
   query: string;
   queryParams?: unknown[];
 }
+
+const getFriendlyDBError = (error: DatabaseError): string => {
+  switch (error.code) {
+    case '23503': {
+      const match = error.detail?.match(/Key \((.+?)\)=\((.+?)\)/);
+      const field = match?.[1]?.replace(/_/g, ' ') || 'record';
+      return `Cannot complete this action because ${field} is still referenced by other records`;
+    }
+    case '23505': {
+      const match = error.detail?.match(/Key \((.+?)\)=\((.+?)\)/);
+      const field = match?.[1]?.replace(/_/g, ' ') || 'value';
+      const value = match?.[2] || '';
+      return `A record with this ${field} (${value}) already exists`;
+    }
+    case '23502': {
+      const column = error.column?.replace(/_/g, ' ') || 'field';
+      return `${column} is required and cannot be empty`;
+    }
+    default:
+      return 'An error occurred while processing your request. Please try again later.';
+  }
+};
 
 export const processDBRequest = async <T extends QueryResultRow = any>({
   query,
@@ -16,7 +38,13 @@ export const processDBRequest = async <T extends QueryResultRow = any>({
     const result = await db.query<T>(query, queryParams);
     return result;
   } catch (error) {
-    console.log(error);
-    throw new ApiError(500, ERROR_MESSAGES.DATABASE_ERROR);
+    console.error(error);
+    if (error instanceof DatabaseError) {
+      throw new ApiError(error.code === '23503' ? 409 : 500, getFriendlyDBError(error));
+    }
+    throw new ApiError(
+      500,
+      'An error occurred while processing your request. Please try again later.'
+    );
   }
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,8 @@ services:
       dockerfile: Dockerfile
       target: dev
     profiles: ["dev"]
+    ports:
+      - "5008:5008"
     volumes:
       - ./go-service:/app
 

--- a/frontend/src/domains/account/components/change-password.tsx
+++ b/frontend/src/domains/account/components/change-password.tsx
@@ -4,11 +4,13 @@ import { Box, Button, Grid2, Paper, TextField } from '@mui/material';
 import { SerializedError } from '@reduxjs/toolkit';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { useForm } from 'react-hook-form';
+import { useDispatch } from 'react-redux';
 import { toast } from 'react-toastify';
 
 import { getErrorMsg } from '@/utils/helpers/get-error-message';
 import { useChangePwdMutation } from '@/domains/auth/api';
 import { PasswordProps, PasswordSchema } from '@/domains/auth/types';
+import { resetUser } from '@/domains/auth/slice';
 
 const initialState = {
   oldPassword: '',
@@ -17,6 +19,7 @@ const initialState = {
 };
 
 export const ChangePassword = () => {
+  const dispatch = useDispatch();
   const [changePassword, { isLoading: isChangingPassword }] = useChangePwdMutation();
 
   const {
@@ -35,7 +38,7 @@ export const ChangePassword = () => {
     try {
       const result = await changePassword(data).unwrap();
       toast.info(result.message);
-      reset(initialState);
+      dispatch(resetUser());
     } catch (error) {
       toast.error(getErrorMsg(error as FetchBaseQueryError | SerializedError).message);
     }

--- a/frontend/src/domains/auth/types/auth-schema.ts
+++ b/frontend/src/domains/auth/types/auth-schema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const LoginSchema = z.object({
   username: z.string().min(1, 'Username is required'),
-  password: z.string().min(5, 'Password must be at least 6 characters')
+  password: z.string().min(6, 'Password must be at least 6 characters')
 });
 
 export const PasswordSchema = z

--- a/frontend/src/domains/class-teacher/components/manage-class-teacher.tsx
+++ b/frontend/src/domains/class-teacher/components/manage-class-teacher.tsx
@@ -11,7 +11,6 @@ import {
   Radio,
   RadioGroup,
   Select,
-  TextField,
   Typography
 } from '@mui/material';
 import { Controller, UseFormReturn } from 'react-hook-form';
@@ -29,6 +28,7 @@ import {
   useUpdateClassTeacherMutation
 } from '../api/class-teacher-api';
 import { useGetSectionsQuery } from '@/domains/section/api';
+import { useGetClassesQuery } from '@/domains/class/api';
 
 type ManageClassTeacherProps = {
   operation: string;
@@ -42,6 +42,7 @@ export const ManageClassTeacher: React.FC<ManageClassTeacherProps> = ({
   methods
 }) => {
   const { data, isLoading } = useGetSectionsQuery();
+  const { data: classData, isLoading: loadingClasses } = useGetClassesQuery();
   const [getTeachers] = useLazyGetTeachersQuery();
   const [teachers, setTeachers] = React.useState<Teacher[]>([]);
   const [addClassTeacher, { isLoading: addingClassTeacher }] = useAddClassTeacherMutation();
@@ -49,7 +50,6 @@ export const ManageClassTeacher: React.FC<ManageClassTeacherProps> = ({
   const navigate = useNavigate();
 
   const {
-    register,
     handleSubmit,
     control,
     formState: { errors },
@@ -92,15 +92,37 @@ export const ManageClassTeacher: React.FC<ManageClassTeacherProps> = ({
           {operation} Class Teacher
         </Typography>
         <form onSubmit={handleSubmit(onSubmit)}>
-          <TextField
-            {...register('class')}
-            error={Boolean(errors.class)}
-            helperText={errors.class?.message}
-            label='Class Name'
-            fullWidth
-            size='small'
-            slotProps={{ inputLabel: { shrink: true } }}
-          />
+          <FormControl fullWidth size='small' error={Boolean(errors.class)}>
+            <InputLabel id='class-name-label' shrink>
+              Class Name
+            </InputLabel>
+            <Controller
+              name='class'
+              control={control}
+              render={({ field: { onChange, value }, fieldState: { error } }) => (
+                <>
+                  <Select
+                    labelId='class-name-label'
+                    label='Class Name'
+                    value={value}
+                    onChange={onChange}
+                    notched
+                  >
+                    {loadingClasses ? (
+                      <MenuItem disabled>Loading...</MenuItem>
+                    ) : (
+                      classData?.classes?.map(({ name }) => (
+                        <MenuItem key={name} value={name}>
+                          {name}
+                        </MenuItem>
+                      ))
+                    )}
+                  </Select>
+                  <FormHelperText>{error?.message}</FormHelperText>
+                </>
+              )}
+            />
+          </FormControl>
 
           <FormControl>
             <FormLabel id='demo-controlled-radio-buttons-group' sx={{ mt: 2 }}>

--- a/frontend/src/domains/class-teacher/pages/list/class-teacher-data.tsx
+++ b/frontend/src/domains/class-teacher/pages/list/class-teacher-data.tsx
@@ -18,8 +18,8 @@ export const ClassTeacherData = () => {
         header: 'CLASS'
       },
       {
-        accessorKey: 'sections',
-        header: 'SECTIONS'
+        accessorKey: 'section',
+        header: 'SECTION'
       },
       {
         accessorKey: 'teacher',

--- a/frontend/src/domains/dashboard/components/grid-card.tsx
+++ b/frontend/src/domains/dashboard/components/grid-card.tsx
@@ -1,34 +1,21 @@
 import * as React from 'react';
-import { TrendingDown, TrendingUp } from '@mui/icons-material';
-import { Box, Card, CardContent, Chip, Typography } from '@mui/material';
+import { Card, CardContent, Typography } from '@mui/material';
 
 type GridCardType = {
   heading: string;
-  totalNumberCurrentYear: number;
-  totalNumberPercInComparisonFromPrevYear: number;
-  totalNumberValueInComparisonFromPrevYear: number;
+  total: number;
 };
 
-export const GridCard: React.FC<GridCardType> = (props) => {
-  const { heading, totalNumberCurrentYear, totalNumberPercInComparisonFromPrevYear } = props;
-  const isNegative = totalNumberPercInComparisonFromPrevYear < 0 ? true : false;
-
+export const GridCard: React.FC<GridCardType> = ({ heading, total }) => {
   return (
     <Card>
       <CardContent>
         <Typography component='div' color='text.secondary' gutterBottom>
           {heading}
         </Typography>
-        <Box sx={{ display: 'flex' }}>
-          <Typography variant='h6' gutterBottom sx={{ pr: 2 }}>
-            {totalNumberCurrentYear}
-          </Typography>
-          <Chip
-            icon={isNegative ? <TrendingDown /> : <TrendingUp />}
-            label={`${totalNumberPercInComparisonFromPrevYear}%`}
-            color={isNegative ? 'error' : 'success'}
-          />
-        </Box>
+        <Typography variant='h6' gutterBottom>
+          {total}
+        </Typography>
       </CardContent>
     </Card>
   );

--- a/frontend/src/domains/dashboard/pages/dashboard-page.tsx
+++ b/frontend/src/domains/dashboard/pages/dashboard-page.tsx
@@ -28,13 +28,13 @@ export const DashboardPage = () => {
       {currentUserRole === 'admin' && (
         <>
           <Grid2 size={{ xs: 12, md: 4 }}>
-            <GridCard {...students} heading='Total Students' />
+            <GridCard total={students.total} heading='Total Students' />
           </Grid2>
           <Grid2 size={{ xs: 12, md: 4 }}>
-            <GridCard {...teachers} heading='Total Teachers' />
+            <GridCard total={teachers.total} heading='Total Teachers' />
           </Grid2>
           <Grid2 size={{ xs: 12, md: 4 }}>
-            <GridCard {...parents} heading='Total Parents' />
+            <GridCard total={parents.total} heading='Total Parents' />
           </Grid2>
         </>
       )}

--- a/frontend/src/domains/dashboard/types/dashboard-type.ts
+++ b/frontend/src/domains/dashboard/types/dashboard-type.ts
@@ -2,10 +2,7 @@ import { MyLeavePolicy } from '@/domains/leave/types';
 import { Notice } from '@/domains/notice/types';
 
 type GeneralData = {
-  heading: string;
-  totalNumberCurrentYear: number;
-  totalNumberPercInComparisonFromPrevYear: number;
-  totalNumberValueInComparisonFromPrevYear: number;
+  total: number;
 };
 
 export type CelebrationProps = {

--- a/frontend/src/domains/leave/api/leave-api.ts
+++ b/frontend/src/domains/leave/api/leave-api.ts
@@ -129,10 +129,10 @@ export const leaveApi = api.injectEndpoints({
         result ? [{ type: Tag.LEAVE_POLICIES, id }] : []
     }),
     addUserToPolicy: builder.mutation<{ message: string }, AddUserToPolicy>({
-      query: ({ userList, id }) => ({
+      query: ({ users, id }) => ({
         url: `/leave/policies/${id}/users`,
         method: 'POST',
-        body: { users: userList }
+        body: { users }
       }),
       invalidatesTags: (result) =>
         result

--- a/frontend/src/domains/leave/pages/define/components/add-people-to-policy.tsx
+++ b/frontend/src/domains/leave/pages/define/components/add-people-to-policy.tsx
@@ -59,8 +59,7 @@ export const AddPeopleToPolicy: React.FC<AddPeopleToPolicyProps> = ({ policyId, 
   const handleAddPeopleSubmit = async (data: PolicyUsers) => {
     try {
       const { users } = data;
-      const userList = users.length > 0 ? users.join(',') : '';
-      const result = await addUsersToPolicy({ userList, id: policyId }).unwrap();
+      const result = await addUsersToPolicy({ users, id: policyId }).unwrap();
       toast.success(result.message);
       closeModal();
     } catch (error) {

--- a/frontend/src/domains/leave/types/leave-type.ts
+++ b/frontend/src/domains/leave/types/leave-type.ts
@@ -71,7 +71,7 @@ export type PolicyUserData = {
 };
 
 export type AddUserToPolicy = {
-  userList: string;
+  users: number[];
   id: number;
 };
 

--- a/frontend/src/domains/notice/pages/add-notice-page.tsx
+++ b/frontend/src/domains/notice/pages/add-notice-page.tsx
@@ -30,7 +30,8 @@ export const AddNotice = () => {
 
   const methods = useForm<NoticeFormProps>({
     defaultValues: initialState,
-    resolver: zodResolver(NoticeFormSchema)
+    resolver: zodResolver(NoticeFormSchema),
+    mode: 'onBlur'
   });
 
   const onSaveNotice = async (data: NoticeFormProps) => {

--- a/frontend/src/domains/notice/pages/edit-notice-page.tsx
+++ b/frontend/src/domains/notice/pages/edit-notice-page.tsx
@@ -32,7 +32,8 @@ export const EditNotice = () => {
 
   const methods = useForm<NoticeFormProps>({
     defaultValues: initialState,
-    resolver: zodResolver(NoticeFormSchema)
+    resolver: zodResolver(NoticeFormSchema),
+    mode: 'onBlur'
   });
 
   React.useEffect(() => {

--- a/frontend/src/domains/notice/pages/recipients/notice-recipients-data.tsx
+++ b/frontend/src/domains/notice/pages/recipients/notice-recipients-data.tsx
@@ -23,10 +23,6 @@ export const RecipientData = () => {
       {
         accessorKey: 'primaryDependentName',
         header: 'Dependent Name'
-      },
-      {
-        accessorKey: 'primaryDependentSelect',
-        header: 'Dependent Select'
       }
     ],
     []

--- a/frontend/src/domains/staff/components/views/staff-account-edit.tsx
+++ b/frontend/src/domains/staff/components/views/staff-account-edit.tsx
@@ -12,6 +12,7 @@ import { parseISO } from 'date-fns';
 
 import { PageContentHeader } from '@/components/page-content-header';
 import { getErrorMsg } from '@/utils/helpers/get-error-message';
+import { API_DATE_FORMAT, getFormattedDate } from '@/utils/helpers/date';
 import { useGetStaffDetail } from '../../hooks';
 import { StaffFormProps, StaffFormSchema } from '../../types';
 import {
@@ -62,7 +63,13 @@ export const StaffAccountEdit: React.FC<StaffAccountEditProps> = ({
 
   const onUpdateStaff = async (data: StaffFormProps) => {
     try {
-      const result = await updateStaff({ id: Number(id)!, ...data }).unwrap();
+      const { dob, joinDate, roleName, reporterName, ...rest } = data;
+      const payload = {
+        ...rest,
+        dob: getFormattedDate(dob, API_DATE_FORMAT),
+        joinDate: getFormattedDate(joinDate, API_DATE_FORMAT)
+      };
+      const result = await updateStaff({ id: Number(id)!, ...payload }).unwrap();
       toast.info(result.message);
       navigate(redirectPath);
     } catch (error) {

--- a/frontend/src/domains/staff/components/views/staff-account-edit.tsx
+++ b/frontend/src/domains/staff/components/views/staff-account-edit.tsx
@@ -42,7 +42,8 @@ export const StaffAccountEdit: React.FC<StaffAccountEditProps> = ({
 
   const methods = useForm<StaffFormProps>({
     defaultValues: staffInitialState,
-    resolver: zodResolver(StaffFormSchema)
+    resolver: zodResolver(StaffFormSchema),
+    mode: 'onBlur'
   });
 
   React.useEffect(() => {

--- a/frontend/src/domains/staff/components/views/staff-account-edit.tsx
+++ b/frontend/src/domains/staff/components/views/staff-account-edit.tsx
@@ -64,11 +64,13 @@ export const StaffAccountEdit: React.FC<StaffAccountEditProps> = ({
 
   const onUpdateStaff = async (data: StaffFormProps) => {
     try {
-      const { dob, joinDate, roleName, reporterName, ...rest } = data;
+      const { dob, joinDate, ...rest } = data;
       const payload = {
         ...rest,
         dob: getFormattedDate(dob, API_DATE_FORMAT),
-        joinDate: getFormattedDate(joinDate, API_DATE_FORMAT)
+        joinDate: getFormattedDate(joinDate, API_DATE_FORMAT),
+        roleName: undefined,
+        reporterName: undefined
       };
       const result = await updateStaff({ id: Number(id)!, ...payload }).unwrap();
       toast.info(result.message);

--- a/frontend/src/domains/staff/pages/add-staff-page.tsx
+++ b/frontend/src/domains/staff/pages/add-staff-page.tsx
@@ -28,7 +28,8 @@ export const AddStaff = () => {
 
   const methods = useForm<StaffFormProps>({
     defaultValues: staffInitialState,
-    resolver: zodResolver(StaffFormSchema)
+    resolver: zodResolver(StaffFormSchema),
+    mode: 'onBlur'
   });
 
   const onReset = () => {

--- a/frontend/src/domains/staff/pages/add-staff-page.tsx
+++ b/frontend/src/domains/staff/pages/add-staff-page.tsx
@@ -10,6 +10,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { PageContentHeader } from '@/components/page-content-header';
 import { getErrorMsg } from '@/utils/helpers/get-error-message';
+import { API_DATE_FORMAT, getFormattedDate } from '@/utils/helpers/date';
 import { useAddStaffMutation } from '../api/staff-api';
 import { StaffFormProps, StaffFormSchema } from '../types';
 import {
@@ -35,7 +36,13 @@ export const AddStaff = () => {
   };
   const onSave = async (data: StaffFormProps) => {
     try {
-      const result = await addNewStaff(data).unwrap();
+      const { dob, joinDate, roleName, reporterName, ...rest } = data;
+      const payload = {
+        ...rest,
+        dob: getFormattedDate(dob, API_DATE_FORMAT),
+        joinDate: getFormattedDate(joinDate, API_DATE_FORMAT)
+      };
+      const result = await addNewStaff(payload).unwrap();
       toast.info(result.message);
       navigate('/app/staffs');
     } catch (error) {

--- a/frontend/src/domains/staff/pages/add-staff-page.tsx
+++ b/frontend/src/domains/staff/pages/add-staff-page.tsx
@@ -37,11 +37,13 @@ export const AddStaff = () => {
   };
   const onSave = async (data: StaffFormProps) => {
     try {
-      const { dob, joinDate, roleName, reporterName, ...rest } = data;
+      const { dob, joinDate, ...rest } = data;
       const payload = {
         ...rest,
         dob: getFormattedDate(dob, API_DATE_FORMAT),
-        joinDate: getFormattedDate(joinDate, API_DATE_FORMAT)
+        joinDate: getFormattedDate(joinDate, API_DATE_FORMAT),
+        roleName: undefined,
+        reporterName: undefined
       };
       const result = await addNewStaff(payload).unwrap();
       toast.info(result.message);

--- a/frontend/src/domains/staff/types/staff-schema.ts
+++ b/frontend/src/domains/staff/types/staff-schema.ts
@@ -14,7 +14,7 @@ export const BasicInfoSchema = z.object({
   roleName: z.string().optional().nullable(),
   gender: z.string().min(1, 'Gender is required'),
   maritalStatus: z.string().min(1, 'Marital Status is required'),
-  phone: z.string().min(1, 'Phone is required'),
+  phone: z.string().min(1, 'Phone is required').regex(/^[\d\s+\-()]+$/, 'Invalid phone number'),
   email: z.string().min(1, 'Email is required').email('Invalid email address'),
   dob: z.union([z.date(), z.string()]),
   joinDate: z.union([z.date(), z.string()]),
@@ -28,7 +28,10 @@ export const AddressInfoSchema = z.object({
 export const ParentsInfoSchema = z.object({
   fatherName: z.string().min(1, 'Father name is required'),
   motherName: z.string().optional(),
-  emergencyPhone: z.string().min(1, 'Emergency phone is required')
+  emergencyPhone: z
+    .string()
+    .min(1, 'Emergency phone is required')
+    .regex(/^[\d\s+\-()]+$/, 'Invalid phone number')
 });
 export const OtherInfoSchema = z.object({
   reporterId: z.number().min(1, 'You must select at least one person'),

--- a/frontend/src/domains/staff/types/staff-schema.ts
+++ b/frontend/src/domains/staff/types/staff-schema.ts
@@ -14,7 +14,10 @@ export const BasicInfoSchema = z.object({
   roleName: z.string().optional().nullable(),
   gender: z.string().min(1, 'Gender is required'),
   maritalStatus: z.string().min(1, 'Marital Status is required'),
-  phone: z.string().min(1, 'Phone is required').regex(/^[\d\s+\-()]+$/, 'Invalid phone number'),
+  phone: z
+    .string()
+    .min(1, 'Phone is required')
+    .regex(/^[\d\s+\-()]+$/, 'Invalid phone number'),
   email: z.string().min(1, 'Email is required').email('Invalid email address'),
   dob: z.union([z.date(), z.string()]),
   joinDate: z.union([z.date(), z.string()]),

--- a/frontend/src/domains/staff/types/staff-schema.ts
+++ b/frontend/src/domains/staff/types/staff-schema.ts
@@ -16,8 +16,8 @@ export const BasicInfoSchema = z.object({
   maritalStatus: z.string().min(1, 'Marital Status is required'),
   phone: z.string().min(1, 'Phone is required'),
   email: z.string().min(1, 'Email is required'),
-  dob: z.date(),
-  joinDate: z.date(),
+  dob: z.union([z.date(), z.string()]),
+  joinDate: z.union([z.date(), z.string()]),
   qualification: z.string().optional(),
   experience: z.string().optional()
 });

--- a/frontend/src/domains/staff/types/staff-schema.ts
+++ b/frontend/src/domains/staff/types/staff-schema.ts
@@ -15,7 +15,7 @@ export const BasicInfoSchema = z.object({
   gender: z.string().min(1, 'Gender is required'),
   maritalStatus: z.string().min(1, 'Marital Status is required'),
   phone: z.string().min(1, 'Phone is required'),
-  email: z.string().min(1, 'Email is required'),
+  email: z.string().min(1, 'Email is required').email('Invalid email address'),
   dob: z.union([z.date(), z.string()]),
   joinDate: z.union([z.date(), z.string()]),
   qualification: z.string().optional(),

--- a/frontend/src/domains/student/components/views/student-account-edit.tsx
+++ b/frontend/src/domains/student/components/views/student-account-edit.tsx
@@ -37,7 +37,8 @@ export const StudentAccountEdit: React.FC<StudentAccountEditProps> = ({
 }) => {
   const methods = useForm<StudentProps>({
     defaultValues: studentFormInitialState,
-    resolver: zodResolver(StudentSchema)
+    resolver: zodResolver(StudentSchema),
+    mode: 'onBlur'
   });
   const [updateStudent, { isLoading }] = useUpdateStudentMutation();
   const navigate = useNavigate();

--- a/frontend/src/domains/student/pages/add-student-page.tsx
+++ b/frontend/src/domains/student/pages/add-student-page.tsx
@@ -28,7 +28,8 @@ export const AddStudent = () => {
 
   const methods = useForm<StudentProps>({
     defaultValues: studentFormInitialState,
-    resolver: zodResolver(StudentSchema)
+    resolver: zodResolver(StudentSchema),
+    mode: 'onBlur'
   });
 
   const onReset = () => {

--- a/frontend/src/domains/student/types/student-schema.ts
+++ b/frontend/src/domains/student/types/student-schema.ts
@@ -18,7 +18,7 @@ export const BasicInfoSchema = z.object({
 export const AcademicInfoSchema = z.object({
   class: z.string().min(1, 'Class is required'),
   section: z.string(),
-  roll: z.string().min(1, 'Roll is required'),
+  roll: z.string().min(1, 'Roll is required').regex(/^\d+$/, 'Roll must be a number'),
   admissionDate: z.union([z.date(), z.string()])
 });
 

--- a/frontend/src/domains/student/types/student-schema.ts
+++ b/frontend/src/domains/student/types/student-schema.ts
@@ -12,7 +12,7 @@ export const BasicInfoSchema = z.object({
   gender: z.string().min(1, 'Gender is required'),
   dob: z.union([z.date(), z.string()]),
   phone: z.string().min(1, 'Phone is required'),
-  email: z.string().min(1, 'Email is required')
+  email: z.string().min(1, 'Email is required').email('Invalid email address')
 });
 
 export const AcademicInfoSchema = z.object({

--- a/frontend/src/domains/student/types/student-schema.ts
+++ b/frontend/src/domains/student/types/student-schema.ts
@@ -11,7 +11,7 @@ export const BasicInfoSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   gender: z.string().min(1, 'Gender is required'),
   dob: z.union([z.date(), z.string()]),
-  phone: z.string().min(1, 'Phone is required'),
+  phone: z.string().min(1, 'Phone is required').regex(/^[\d\s+\-()]+$/, 'Invalid phone number'),
   email: z.string().min(1, 'Email is required').email('Invalid email address')
 });
 
@@ -29,11 +29,14 @@ export const AddressInfoSchema = z.object({
 
 export const ParentsAndGuardianInfoSchema = z.object({
   fatherName: z.string().min(1, 'Father Name is required'),
-  fatherPhone: z.string().optional(),
+  fatherPhone: z.string().regex(/^[\d\s+\-()]*$/, 'Invalid phone number').optional(),
   motherName: z.string().optional(),
-  motherPhone: z.string().optional(),
+  motherPhone: z.string().regex(/^[\d\s+\-()]*$/, 'Invalid phone number').optional(),
   guardianName: z.string().min(1, 'Guardian Name is required'),
-  guardianPhone: z.string().min(1, 'Guardian Phone is required'),
+  guardianPhone: z
+    .string()
+    .min(1, 'Guardian Phone is required')
+    .regex(/^[\d\s+\-()]+$/, 'Invalid phone number'),
   relationOfGuardian: z.string().min(1, 'Relation of guardian is required')
 });
 

--- a/frontend/src/domains/student/types/student-schema.ts
+++ b/frontend/src/domains/student/types/student-schema.ts
@@ -11,7 +11,10 @@ export const BasicInfoSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   gender: z.string().min(1, 'Gender is required'),
   dob: z.union([z.date(), z.string()]),
-  phone: z.string().min(1, 'Phone is required').regex(/^[\d\s+\-()]+$/, 'Invalid phone number'),
+  phone: z
+    .string()
+    .min(1, 'Phone is required')
+    .regex(/^[\d\s+\-()]+$/, 'Invalid phone number'),
   email: z.string().min(1, 'Email is required').email('Invalid email address')
 });
 
@@ -29,9 +32,15 @@ export const AddressInfoSchema = z.object({
 
 export const ParentsAndGuardianInfoSchema = z.object({
   fatherName: z.string().min(1, 'Father Name is required'),
-  fatherPhone: z.string().regex(/^[\d\s+\-()]*$/, 'Invalid phone number').optional(),
+  fatherPhone: z
+    .string()
+    .regex(/^[\d\s+\-()]*$/, 'Invalid phone number')
+    .optional(),
   motherName: z.string().optional(),
-  motherPhone: z.string().regex(/^[\d\s+\-()]*$/, 'Invalid phone number').optional(),
+  motherPhone: z
+    .string()
+    .regex(/^[\d\s+\-()]*$/, 'Invalid phone number')
+    .optional(),
   guardianName: z.string().min(1, 'Guardian Name is required'),
   guardianPhone: z
     .string()

--- a/frontend/src/utils/helpers/get-error-message.ts
+++ b/frontend/src/utils/helpers/get-error-message.ts
@@ -27,6 +27,10 @@ export const getErrorMsg = (
 
     if (apiError?.error) {
       const { error, detail } = apiError;
+      if (Array.isArray(detail) && detail.length > 0) {
+        const fieldErrors = detail.map((d) => d.message).join(', ');
+        return { message: fieldErrors, detail };
+      }
       return { message: error, detail };
     }
 

--- a/seed_db/seed-db.sql
+++ b/seed_db/seed-db.sql
@@ -1,3 +1,6 @@
+-- ============================================================
+-- ACCESS CONTROLS (unchanged - UI/API permission definitions)
+-- ============================================================
 INSERT INTO access_controls(
     name,
     path,
@@ -81,6 +84,7 @@ VALUES
 ('Get student detail', '/api/v1/students/:id', NULL, 'students_parent', NULL, 'api', 'GET'),
 ('Handle student status', '/api/v1/students/:id/status', NULL, 'students_parent', NULL, 'api', 'POST'),
 ('Update student detail', '/api/v1/students/:id', NULL, 'students_parent', NULL, 'api', 'PUT'),
+('Delete student', '/api/v1/students/:id', NULL, 'students_parent', NULL, 'api', 'DELETE'),
 -- end student
 
 -- start communication
@@ -140,6 +144,9 @@ VALUES
 -- end access setting
 ON CONFLICT DO NOTHING;
 
+-- ============================================================
+-- LOOKUP DATA
+-- ============================================================
 ALTER SEQUENCE leave_status_id_seq RESTART WITH 1;
 INSERT INTO leave_status (name) VALUES
 ('On Review'),
@@ -159,11 +166,196 @@ VALUES ('Draft', 'Draft'),
 ('Approve', 'Approved'),
 ('Delete', 'Deleted');
 
-INSERT INTO users(name,email,role_id,created_dt,password, is_active, is_email_verified)
-VALUES('John Doe','admin@school-admin.com',1, now(),'$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU', true, true)
-RETURNING id;
+-- ============================================================
+-- ACADEMIC STRUCTURE
+-- ============================================================
+INSERT INTO sections (name) VALUES ('A'), ('B'), ('C');
 
+INSERT INTO classes (name, sections) VALUES
+('Grade 1', 'A,B'),
+('Grade 2', 'A,B,C'),
+('Grade 3', 'A,B'),
+('Grade 4', 'A'),
+('Grade 5', 'A,B');
+
+INSERT INTO departments (name) VALUES
+('Mathematics'),
+('Science'),
+('English'),
+('History');
+
+-- ============================================================
+-- USERS: 1 Admin + 4 Teachers + 8 Students
+-- All passwords: 3OU4zn3q6Zh9
+-- ============================================================
+ALTER SEQUENCE users_id_seq RESTART WITH 1;
+
+-- Admin (id=1)
+INSERT INTO users (name, email, role_id, password, is_active, is_email_verified, created_dt)
+VALUES ('John Doe', 'admin@school-admin.com', 1,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  true, true, now());
+
+-- Teachers (id=2..5)
+INSERT INTO users (name, email, role_id, reporter_id, password, is_active, is_email_verified, created_dt) VALUES
+('Sarah Miller', 'sarah.miller@school.com', 2, 1,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  true, true, now()),
+('David Chen', 'david.chen@school.com', 2, 1,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  true, true, now()),
+('Emily Watson', 'emily.watson@school.com', 2, 1,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  true, true, now()),
+('Michael Brown', 'michael.brown@school.com', 2, 1,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  true, true, now());
+
+-- Students (id=6..13)
+INSERT INTO users (name, email, role_id, reporter_id, password, is_active, is_email_verified, created_dt) VALUES
+('Alice Johnson', 'alice.johnson@student.com', 3, 2,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  true, true, now()),
+('Bob Williams', 'bob.williams@student.com', 3, 2,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  true, true, now()),
+('Charlie Davis', 'charlie.davis@student.com', 3, 3,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  true, true, now()),
+('Diana Martinez', 'diana.martinez@student.com', 3, 3,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  true, true, now()),
+('Ethan Garcia', 'ethan.garcia@student.com', 3, 4,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  true, true, now()),
+('Fiona Lee', 'fiona.lee@student.com', 3, 4,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  true, true, now()),
+('George Taylor', 'george.taylor@student.com', 3, 5,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  false, true, now()),
+('Hannah Wilson', 'hannah.wilson@student.com', 3, 5,
+  '$argon2id$v=19$m=65536,t=3,p=4$21a+bDbESEI60WO1wRKnvQ$i6OrxqNiHvwtf1Xg3bfU5+AXZG14fegW3p+RSMvq1oU',
+  true, true, now());
+
+-- ============================================================
+-- USER PROFILES
+-- ============================================================
+
+-- Admin profile
 INSERT INTO user_profiles
-(user_id, gender, marital_status, phone,dob,join_dt,qualification,experience,current_address,permanent_address,father_name,mother_name,emergency_phone)
+(user_id, gender, marital_status, phone, dob, join_dt, qualification, experience, current_address, permanent_address, father_name, mother_name, emergency_phone)
 VALUES
-((SELECT currval('users_id_seq')),'Male','Married','4759746607','2024-08-05',NULL,NULL,NULL,NULL,NULL,'stut','lancy','79374304');
+(1, 'Male', 'Married', '0412345678', '1985-03-15', '2020-01-10', 'MEd Administration', '15 years', '42 Admin St, Sydney NSW 2000', '42 Admin St, Sydney NSW 2000', 'Robert Doe', 'Mary Doe', '0498765432');
+
+-- Teacher profiles
+INSERT INTO user_profiles
+(user_id, gender, marital_status, phone, dob, join_dt, qualification, experience, department_id, current_address, permanent_address, father_name, mother_name, emergency_phone)
+VALUES
+(2, 'Female', 'Single', '0423456789', '1990-07-22', '2021-02-15', 'BSc Mathematics', '5 years', 1, '10 Maths Ave, Melbourne VIC 3000', '10 Maths Ave, Melbourne VIC 3000', 'James Miller', 'Karen Miller', '0487654321'),
+(3, 'Male', 'Married', '0434567890', '1988-11-03', '2019-06-01', 'MSc Physics', '8 years', 2, '25 Science Rd, Brisbane QLD 4000', '25 Science Rd, Brisbane QLD 4000', 'Wei Chen', 'Li Chen', '0476543210'),
+(4, 'Female', 'Single', '0445678901', '1992-04-18', '2022-01-20', 'BA English Literature', '3 years', 3, '8 English Ln, Perth WA 6000', '8 English Ln, Perth WA 6000', 'Tom Watson', 'Jane Watson', '0465432109'),
+(5, 'Male', 'Married', '0456789012', '1987-09-30', '2018-08-12', 'MA History', '10 years', 4, '15 History Ct, Adelaide SA 5000', '15 History Ct, Adelaide SA 5000', 'Alan Brown', 'Sue Brown', '0454321098');
+
+-- Student profiles
+INSERT INTO user_profiles
+(user_id, gender, phone, dob, class_name, section_name, roll, admission_dt, current_address, permanent_address, father_name, father_phone, mother_name, mother_phone, guardian_name, guardian_phone, relation_of_guardian)
+VALUES
+(6,  'Female', '0467890123', '2012-05-10', 'Grade 1', 'A', 1,  '2024-01-15', '100 Oak St, Sydney', '100 Oak St, Sydney', 'Mark Johnson', '0411111111', 'Lisa Johnson', '0422222222', 'Mark Johnson', '0411111111', 'Father'),
+(7,  'Male',   '0478901234', '2012-08-20', 'Grade 1', 'A', 2,  '2024-01-15', '200 Elm St, Sydney', '200 Elm St, Sydney', 'Tom Williams', '0433333333', 'Amy Williams', '0444444444', 'Tom Williams', '0433333333', 'Father'),
+(8,  'Male',   '0489012345', '2011-03-14', 'Grade 2', 'A', 1,  '2023-01-10', '300 Pine Ave, Melbourne', '300 Pine Ave, Melbourne', 'James Davis', '0455555555', 'Emma Davis', '0466666666', 'James Davis', '0455555555', 'Father'),
+(9,  'Female', '0490123456', '2011-11-25', 'Grade 2', 'B', 1,  '2023-01-10', '400 Cedar Dr, Melbourne', '400 Cedar Dr, Melbourne', 'Carlos Martinez', '0477777777', 'Rosa Martinez', '0488888888', 'Rosa Martinez', '0488888888', 'Mother'),
+(10, 'Male',   '0401234567', '2010-07-08', 'Grade 3', 'A', 1,  '2022-02-01', '500 Birch Rd, Brisbane', '500 Birch Rd, Brisbane', 'Pedro Garcia', '0499999999', 'Maria Garcia', '0410101010', 'Pedro Garcia', '0499999999', 'Father'),
+(11, 'Female', '0412345670', '2010-12-02', 'Grade 3', 'B', 1,  '2022-02-01', '600 Maple Ct, Brisbane', '600 Maple Ct, Brisbane', 'David Lee', '0420202020', 'Susan Lee', '0430303030', 'Susan Lee', '0430303030', 'Mother'),
+(12, 'Male',   '0423456781', '2009-01-19', 'Grade 4', 'A', 1,  '2021-01-20', '700 Walnut St, Perth', '700 Walnut St, Perth', 'Richard Taylor', '0440404040', 'Beth Taylor', '0450505050', 'Richard Taylor', '0440404040', 'Father'),
+(13, 'Female', '0434567892', '2009-06-30', 'Grade 5', 'A', 1,  '2021-01-20', '800 Spruce Ln, Adelaide', '800 Spruce Ln, Adelaide', 'Peter Wilson', '0460606060', 'Kate Wilson', '0470707070', 'Kate Wilson', '0470707070', 'Mother');
+
+-- ============================================================
+-- CLASS TEACHERS
+-- ============================================================
+INSERT INTO class_teachers (teacher_id, class_name, section_name) VALUES
+(2, 'Grade 1', 'A'),
+(2, 'Grade 1', 'B'),
+(3, 'Grade 2', 'A'),
+(3, 'Grade 2', 'B'),
+(4, 'Grade 3', 'A'),
+(4, 'Grade 3', 'B'),
+(5, 'Grade 4', 'A'),
+(5, 'Grade 5', 'A');
+
+-- ============================================================
+-- LEAVE POLICIES + ASSIGNMENTS
+-- ============================================================
+INSERT INTO leave_policies (name, is_active) VALUES
+('Annual Leave', true),
+('Sick Leave', true),
+('Personal Leave', true);
+
+-- Assign teachers and admin to leave policies
+INSERT INTO user_leave_policy (user_id, leave_policy_id) VALUES
+(1, 1), (1, 2),
+(2, 1), (2, 2), (2, 3),
+(3, 1), (3, 2),
+(4, 1), (4, 3),
+(5, 1), (5, 2), (5, 3);
+
+-- ============================================================
+-- LEAVE REQUESTS (mix of statuses)
+-- ============================================================
+INSERT INTO user_leaves (user_id, leave_policy_id, from_dt, to_dt, note, submitted_dt, status) VALUES
+-- Sarah Miller: approved annual leave
+(2, 1, '2026-04-01', '2026-04-03', 'Family vacation', now(), 1),
+-- Sarah Miller: approved sick leave
+(2, 2, '2026-03-10', '2026-03-11', 'Flu', now(), 2),
+-- David Chen: pending annual leave
+(3, 1, '2026-04-14', '2026-04-18', 'Conference attendance', now(), 1),
+-- David Chen: cancelled request
+(3, 2, '2026-02-20', '2026-02-21', 'Changed plans', now(), 3),
+-- Emily Watson: pending personal leave
+(4, 3, '2026-05-01', '2026-05-02', 'Moving house', now(), 1),
+-- Michael Brown: approved annual leave
+(5, 1, '2026-06-15', '2026-06-20', 'Summer holiday', now(), 2),
+-- Michael Brown: pending sick leave
+(5, 2, '2026-03-25', '2026-03-26', 'Dental appointment', now(), 1);
+
+-- Update approved leaves with approver info
+UPDATE user_leaves SET approved_dt = now(), approver_id = 1 WHERE status = 2;
+
+-- ============================================================
+-- NOTICES (mix of statuses)
+-- ============================================================
+INSERT INTO notices (author_id, title, description, status, recipient_type, created_dt) VALUES
+(1, 'School Reopening', 'School reopens on Monday 7th April. All students must report by 8:30 AM.', 5, 'EV', now() - interval '7 days'),
+(1, 'Parent-Teacher Meeting', 'PTM scheduled for Friday 11th April at 2:00 PM in the main hall.', 5, 'EV', now() - interval '5 days'),
+(2, 'Maths Homework Reminder', 'All Grade 1 students must submit their maths worksheets by Wednesday.', 2, 'SP', now() - interval '2 days'),
+(3, 'Science Fair', 'Science fair registration is now open. Submit your project proposals by end of month.', 1, 'EV', now() - interval '1 day'),
+(1, 'Holiday Schedule', 'Updated holiday schedule for Term 2 has been posted.', 4, 'EV', now() - interval '3 days'),
+(4, 'English Essay Competition', 'Annual essay competition entries due by April 25th. Topic: My Community.', 5, 'EV', now());
+
+-- ============================================================
+-- NOTICE RECIPIENT TYPES
+-- ============================================================
+INSERT INTO notice_recipient_types (role_id, primary_dependent_name, primary_dependent_select) VALUES
+(2, 'Teacher', 'SELECT id, name FROM users WHERE role_id = 2'),
+(3, 'Class', 'SELECT DISTINCT name AS id, name FROM classes');
+
+-- ============================================================
+-- ROLE PERMISSIONS (give admin all permissions)
+-- ============================================================
+INSERT INTO permissions (role_id, access_control_id, type)
+SELECT 1, id, type FROM access_controls
+ON CONFLICT DO NOTHING;
+
+-- Give teachers a subset of permissions (leave, student view, notices)
+INSERT INTO permissions (role_id, access_control_id, type)
+SELECT 2, id, type FROM access_controls
+WHERE path IN (
+  'account', '', 'leave_parent', 'leave/request', 'leave/pending',
+  'students_parent', 'students', 'students/:id',
+  'communication_parent', 'notices', 'notices/add', 'notices/:id', 'notices/edit/:id'
+)
+OR path LIKE '/api/v1/leave/%'
+OR path LIKE '/api/v1/students%'
+OR path LIKE '/api/v1/notices%'
+OR path IN ('/api/v1/dashboard', '/api/v1/teachers')
+ON CONFLICT DO NOTHING;

--- a/seed_db/tables.sql
+++ b/seed_db/tables.sql
@@ -458,7 +458,13 @@ BEGIN
     IF _user_role_id = 1 THEN
         SELECT COUNT(*) INTO _student_total FROM users WHERE role_id = 3;
         SELECT COUNT(*) INTO _teacher_total FROM users WHERE role_id = 2;
-        SELECT COUNT(*) INTO _parent_total FROM users WHERE role_id = 4;
+        SELECT COUNT(*) INTO _parent_total FROM (
+            SELECT father_phone FROM user_profiles
+            WHERE father_phone IS NOT NULL AND father_phone != ''
+            UNION
+            SELECT mother_phone FROM user_profiles
+            WHERE mother_phone IS NOT NULL AND mother_phone != ''
+        ) AS unique_parents;
     ELSE
         _student_total := 0;
         _teacher_total := 0;

--- a/seed_db/tables.sql
+++ b/seed_db/tables.sql
@@ -55,16 +55,16 @@ CREATE TABLE user_profiles(
     phone VARCHAR(20) DEFAULT NULL,
     class_name VARCHAR(50) REFERENCES classes(name)
         ON UPDATE CASCADE
-        ON DELETE SET NULL
+        ON DELETE RESTRICT
         DEFAULT NULL,
     section_name VARCHAR(50) REFERENCES sections(name)
         ON UPDATE CASCADE
-        ON DELETE SET NULL
+        ON DELETE RESTRICT
         DEFAULT NULL,
     roll INTEGER DEFAULT NULL,
     department_id INTEGER REFERENCES departments(id)
         ON UPDATE CASCADE
-        ON DELETE SET NULL
+        ON DELETE RESTRICT
         DEFAULT NULL,
     admission_dt DATE DEFAULT NULL,
     father_name VARCHAR(50) DEFAULT NULL,
@@ -117,10 +117,10 @@ CREATE TABLE class_teachers(
     teacher_id INTEGER REFERENCES users(id),
     class_name VARCHAR(50) REFERENCES classes(name)
         ON UPDATE CASCADE
-        ON DELETE SET NULL,
+        ON DELETE RESTRICT,
     section_name VARCHAR(30) REFERENCES sections(name)
         ON UPDATE CASCADE
-        ON DELETE SET NULL
+        ON DELETE RESTRICT
 );
 
 CREATE TABLE notice_status(

--- a/seed_db/tables.sql
+++ b/seed_db/tables.sql
@@ -435,20 +435,9 @@ AS $BODY$
 DECLARE
     _user_role_id INTEGER;
 
-    _student_count_current_year INTEGER;
-    _student_count_previous_year INTEGER;
-    _student_value_comparison INTEGER;
-    _student_perc_comparison FLOAT;
-
-    _teacher_count_current_year INTEGER;
-    _teacher_count_previous_year INTEGER;
-    _teacher_value_comparison INTEGER;
-    _teacher_perc_comparison FLOAT;
-
-    _parent_count_current_year INTEGER;
-    _parent_count_previous_year INTEGER;
-    _parent_value_comparison INTEGER;
-    _parent_perc_comparison FLOAT;
+    _student_total INTEGER;
+    _teacher_total INTEGER;
+    _parent_total INTEGER;
 
     _notices_data JSONB;
     _leave_policies_data JSONB;
@@ -466,78 +455,14 @@ BEGIN
         RAISE EXCEPTION 'Role does not exist';
     END IF;
 
-    --student
     IF _user_role_id = 1 THEN
-        SELECT COUNT(*) INTO _student_count_current_year
-        FROM users t1
-        JOIN user_profiles t2 ON t1.id = t2.user_id
-        WHERE t1.role_id = 3
-        AND EXTRACT(YEAR FROM t2.admission_dt) = EXTRACT(YEAR FROM CURRENT_DATE);
-
-        SELECT COUNT(*) INTO _student_count_previous_year
-        FROM users t1
-        JOIN user_profiles t2 ON t1.id = t2.user_id
-        WHERE t1.role_id = 3
-        AND EXTRACT(YEAR FROM t2.admission_dt) = EXTRACT(YEAR FROM CURRENT_DATE) - 1;
-
-        _student_value_comparison := _student_count_current_year - _student_count_previous_year;
-        IF _student_count_previous_year = 0 THEN
-            _student_perc_comparison := 0;
-        ELSE
-            _student_perc_comparison := (_student_value_comparison::FLOAT / _student_count_previous_year) * 100;
-        END IF;
-
-        --teacher
-        SELECT COUNT(*) INTO _teacher_count_current_year
-        FROM users t1
-        JOIN user_profiles t2 ON t1.id = t2.user_id
-        WHERE t1.role_id = 2
-        AND EXTRACT(YEAR FROM t2.join_dt) = EXTRACT(YEAR FROM CURRENT_DATE);
-
-        SELECT COUNT(*) INTO _teacher_count_previous_year
-        FROM users t1
-        JOIN user_profiles t2 ON t1.id = t2.user_id
-        WHERE t1.role_id = 2
-        AND EXTRACT(YEAR FROM t2.join_dt) = EXTRACT(YEAR FROM CURRENT_DATE) - 1;
-
-        _teacher_value_comparison := _teacher_count_current_year - _teacher_count_previous_year;
-        IF _teacher_count_previous_year = 0 THEN
-            _teacher_perc_comparison := 0;
-        ELSE
-            _teacher_perc_comparison := (_teacher_value_comparison::FLOAT / _teacher_count_previous_year) * 100;
-        END IF;
-
-        --parents
-        SELECT COUNT(*) INTO _parent_count_current_year
-        FROM users t1
-        JOIN user_profiles t2 ON t1.id = t2.user_id
-        WHERE t1.role_id = 4
-        AND EXTRACT(YEAR FROM t2.join_dt) = EXTRACT(YEAR FROM CURRENT_DATE);
-
-        SELECT COUNT(*) INTO _parent_count_previous_year
-        FROM users t1
-        JOIN user_profiles t2 ON t1.id = t2.user_id
-        WHERE t1.role_id = 4
-        AND EXTRACT(YEAR FROM t2.join_dt) = EXTRACT(YEAR FROM CURRENT_DATE) - 1;
-
-        _parent_value_comparison := _parent_count_current_year - _parent_count_previous_year;
-        IF _parent_count_previous_year = 0 THEN
-            _parent_perc_comparison := 0;
-        ELSE
-            _parent_perc_comparison := (_parent_value_comparison::FLOAT / _parent_count_previous_year) * 100;
-        END IF;
+        SELECT COUNT(*) INTO _student_total FROM users WHERE role_id = 3;
+        SELECT COUNT(*) INTO _teacher_total FROM users WHERE role_id = 2;
+        SELECT COUNT(*) INTO _parent_total FROM users WHERE role_id = 4;
     ELSE
-        _student_count_current_year := 0::INTEGER;
-        _student_perc_comparison := 0::FLOAT;
-        _student_value_comparison := 0::INTEGER;
-
-        _teacher_count_current_year := 0::INTEGER;
-        _teacher_perc_comparison := 0::FLOAT;
-        _teacher_value_comparison := 0::INTEGER;
-
-        _parent_count_current_year := 0::INTEGER;
-        _parent_perc_comparison := 0::FLOAT;
-        _parent_value_comparison := 0::INTEGER;
+        _student_total := 0;
+        _teacher_total := 0;
+        _parent_total := 0;
     END IF;
 
     -- get notices
@@ -703,21 +628,9 @@ BEGIN
 
     -- Build and return the final JSON object
     RETURN JSON_BUILD_OBJECT(
-        'students', JSON_BUILD_OBJECT(
-            'totalNumberCurrentYear', _student_count_current_year,
-            'totalNumberPercInComparisonFromPrevYear', _student_perc_comparison,
-            'totalNumberValueInComparisonFromPrevYear', _student_value_comparison
-        ),
-        'teachers', JSON_BUILD_OBJECT(
-            'totalNumberCurrentYear', _teacher_count_current_year,
-            'totalNumberPercInComparisonFromPrevYear', _teacher_perc_comparison,
-            'totalNumberValueInComparisonFromPrevYear', _teacher_value_comparison
-        ),
-        'parents', JSON_BUILD_OBJECT(
-            'totalNumberCurrentYear', _parent_count_current_year,
-            'totalNumberPercInComparisonFromPrevYear', _parent_perc_comparison,
-            'totalNumberValueInComparisonFromPrevYear', _parent_value_comparison
-        ),
+        'students', JSON_BUILD_OBJECT('total', _student_total),
+        'teachers', JSON_BUILD_OBJECT('total', _teacher_total),
+        'parents', JSON_BUILD_OBJECT('total', _parent_total),
         'notices', _notices_data,
         'leavePolicies', _leave_policies_data,
         'leaveHistory', _leave_histories_data,


### PR DESCRIPTION
## Summary

### Form validation and submission consistency
- Fixed `getErrorMsg` to surface field-level validation errors in toasts instead of generic "Validation error"
- Added backend Zod validation schemas for all 12 modules that were missing them: notices, staffs, leave, classes, class-teacher, sections, departments, roles-and-permissions, access-control, account, and auth
- Aligned student backend schema field names with frontend (`className`/`sectionName` to `class`/`section`, added missing `admissionDate` and `systemAccess`)
- Added email format validation (`.email()`) and phone number format validation to student and staff frontend schemas
- Added roll numeric validation on frontend and backend
- Enabled `onBlur` validation mode on all major forms so fields turn red as the user tabs away
- Fixed staff form to format `dob`/`joinDate` as `yyyy-MM-dd` strings before submission and strip display-only fields
- Fixed frontend login schema password `min(5)` to `min(6)` to match backend
- Fixed leave policy "add people" sending user IDs as comma-joined string instead of number array
- Added `hierarchy_id` to access-control backend schema (required by repository but was being stripped)

### Database integrity and error handling
- Changed `ON DELETE SET NULL` to `ON DELETE RESTRICT` on class/section/department foreign keys to prevent silent data loss
- Added user-friendly DB constraint error messages (FK violations, unique violations, NOT NULL violations) instead of generic "An error occurred"
- SP error descriptions logged server-side only, no longer leaked to frontend as raw SQL
- Added null fallback for student/staff service error messages

### UI/UX bug fixes
- Fixed class-teacher table `sections` column accessor (was `sections`, API returns `section`)
- Replaced class-teacher form class name text input with dropdown of existing classes
- Fixed class-teachers list returning 404 on empty list instead of empty array
- Removed raw SQL query column from notice recipients table and API response
- Fixed dashboard totals to count all students/teachers instead of filtering by current year admission date
- Fixed parent count to use unique father/mother phone numbers instead of non-existent role_id=4
- Removed percentage increase badges from dashboard cards
- Fixed logout returning HTTP 204 (body discarded per spec) causing "unable to log out" toast
- Invalidated old refresh tokens on password change
- User now logged out and redirected to login after password change
- Removed go-service port exposure from prod Docker profile (internal only)
