### PR TITLE
fix: restore CHAL-0006 student CRUD lost in PR #6 merge

### DIFF
--- a/backend/src/modules/students/students-controller.ts
+++ b/backend/src/modules/students/students-controller.ts
@@ -5,27 +5,52 @@ import {
   addNewStudent,
   getStudentDetail,
   setStudentStatus,
-  updateStudent
+  updateStudent,
+  deleteStudent,
 } from './students-service';
 
 const handleGetAllStudents = asyncHandler(async (req: Request, res: Response) => {
-  //write your code
+  const { name, className, section, roll } = req.query as {
+    name?: string;
+    className?: string;
+    section?: string;
+    roll?: string;
+  };
+  const students = await getAllStudents({ name, className, section, roll });
+  res.json({ students });
 });
 
 const handleAddStudent = asyncHandler(async (req: Request, res: Response) => {
-  //write your code
+  const payload = req.body;
+  const message = await addNewStudent(payload);
+  res.json(message);
 });
 
 const handleUpdateStudent = asyncHandler(async (req: Request, res: Response) => {
-  //write your code
+  const id = req.params.id;
+  const payload = req.body;
+  const message = await updateStudent({ ...payload, userId: id });
+  res.json(message);
 });
 
 const handleGetStudentDetail = asyncHandler(async (req: Request, res: Response) => {
-  //write your code
+  const id = req.params.id;
+  const student = await getStudentDetail(id);
+  res.json(student);
 });
 
 const handleStudentStatus = asyncHandler(async (req: Request, res: Response) => {
-  //write your code
+  const userId = req.params.id;
+  const { status } = req.body;
+  const { id: reviewerId } = req.user!;
+  const message = await setStudentStatus({ userId, reviewerId, status });
+  res.json(message);
+});
+
+const handleDeleteStudent = asyncHandler(async (req: Request, res: Response) => {
+  const id = req.params.id;
+  const message = await deleteStudent(id);
+  res.json(message);
 });
 
 export {
@@ -33,5 +58,6 @@ export {
   handleGetStudentDetail,
   handleAddStudent,
   handleStudentStatus,
-  handleUpdateStudent
+  handleUpdateStudent,
+  handleDeleteStudent,
 };

--- a/backend/src/modules/students/students-controller.ts
+++ b/backend/src/modules/students/students-controller.ts
@@ -6,7 +6,7 @@ import {
   getStudentDetail,
   setStudentStatus,
   updateStudent,
-  deleteStudent,
+  deleteStudent
 } from './students-service';
 
 const handleGetAllStudents = asyncHandler(async (req: Request, res: Response) => {
@@ -59,5 +59,5 @@ export {
   handleAddStudent,
   handleStudentStatus,
   handleUpdateStudent,
-  handleDeleteStudent,
+  handleDeleteStudent
 };

--- a/backend/src/modules/students/students-repository.ts
+++ b/backend/src/modules/students/students-repository.ts
@@ -115,7 +115,7 @@ const findStudentToUpdate = async (payload: {
 }): Promise<any[]> => {
   const {
     basicDetails: { name, email },
-    id,
+    id
   } = payload;
   const currentDate = new Date();
   const query = `
@@ -133,10 +133,9 @@ const deleteStudentById = async (id: string | number): Promise<number> => {
   try {
     await client.query('BEGIN');
     await client.query('DELETE FROM user_profiles WHERE user_id = $1', [id]);
-    const { rowCount } = await client.query(
-      'DELETE FROM users WHERE id = $1 AND role_id = 3',
-      [id],
-    );
+    const { rowCount } = await client.query('DELETE FROM users WHERE id = $1 AND role_id = 3', [
+      id
+    ]);
     await client.query('COMMIT');
     return rowCount!;
   } catch (error) {
@@ -154,5 +153,5 @@ export {
   findStudentDetail,
   findStudentToSetStatus,
   findStudentToUpdate,
-  deleteStudentById,
+  deleteStudentById
 };

--- a/backend/src/modules/students/students-repository.ts
+++ b/backend/src/modules/students/students-repository.ts
@@ -1,4 +1,5 @@
 import { processDBRequest } from '../../utils';
+import { db } from '../../config';
 
 const getRoleId = async (roleName: string): Promise<number> => {
   const query = 'SELECT id FROM roles WHERE name ILIKE $1';
@@ -114,7 +115,7 @@ const findStudentToUpdate = async (payload: {
 }): Promise<any[]> => {
   const {
     basicDetails: { name, email },
-    id
+    id,
   } = payload;
   const currentDate = new Date();
   const query = `
@@ -127,11 +128,31 @@ const findStudentToUpdate = async (payload: {
   return rows;
 };
 
+const deleteStudentById = async (id: string | number): Promise<number> => {
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('DELETE FROM user_profiles WHERE user_id = $1', [id]);
+    const { rowCount } = await client.query(
+      'DELETE FROM users WHERE id = $1 AND role_id = 3',
+      [id],
+    );
+    await client.query('COMMIT');
+    return rowCount!;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
 export {
   getRoleId,
   findAllStudents,
   addOrUpdateStudent,
   findStudentDetail,
   findStudentToSetStatus,
-  findStudentToUpdate
+  findStudentToUpdate,
+  deleteStudentById,
 };

--- a/backend/src/modules/students/students-router.ts
+++ b/backend/src/modules/students/students-router.ts
@@ -6,7 +6,7 @@ import {
   studentIdParamSchema,
   addStudentSchema,
   updateStudentSchema,
-  studentStatusSchema,
+  studentStatusSchema
 } from './students-schema';
 
 const router = Router();
@@ -17,13 +17,9 @@ router.get('/:id', validateRequest(studentIdParamSchema), studentController.hand
 router.post(
   '/:id/status',
   validateRequest(studentStatusSchema),
-  studentController.handleStudentStatus,
+  studentController.handleStudentStatus
 );
 router.put('/:id', validateRequest(updateStudentSchema), studentController.handleUpdateStudent);
-router.delete(
-  '/:id',
-  validateRequest(studentIdParamSchema),
-  studentController.handleDeleteStudent,
-);
+router.delete('/:id', validateRequest(studentIdParamSchema), studentController.handleDeleteStudent);
 
 export { router as studentsRoutes };

--- a/backend/src/modules/students/students-router.ts
+++ b/backend/src/modules/students/students-router.ts
@@ -1,12 +1,29 @@
 import { Router } from 'express';
 import * as studentController from './students-controller';
+import { validateRequest } from '../../utils';
+import {
+  getStudentsSchema,
+  studentIdParamSchema,
+  addStudentSchema,
+  updateStudentSchema,
+  studentStatusSchema,
+} from './students-schema';
 
 const router = Router();
 
-router.get('', studentController.handleGetAllStudents);
-router.post('', studentController.handleAddStudent);
-router.get('/:id', studentController.handleGetStudentDetail);
-router.post('/:id/status', studentController.handleStudentStatus);
-router.put('/:id', studentController.handleUpdateStudent);
+router.get('', validateRequest(getStudentsSchema), studentController.handleGetAllStudents);
+router.post('', validateRequest(addStudentSchema), studentController.handleAddStudent);
+router.get('/:id', validateRequest(studentIdParamSchema), studentController.handleGetStudentDetail);
+router.post(
+  '/:id/status',
+  validateRequest(studentStatusSchema),
+  studentController.handleStudentStatus,
+);
+router.put('/:id', validateRequest(updateStudentSchema), studentController.handleUpdateStudent);
+router.delete(
+  '/:id',
+  validateRequest(studentIdParamSchema),
+  studentController.handleDeleteStudent,
+);
 
 export { router as studentsRoutes };

--- a/backend/src/modules/students/students-schema.ts
+++ b/backend/src/modules/students/students-schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 const idParam = z.object({
-  id: z.string().regex(/^\d+$/, 'Student ID must be a number'),
+  id: z.string().regex(/^\d+$/, 'Student ID must be a number')
 });
 
 const studentBodyFields = {
@@ -21,7 +21,7 @@ const studentBodyFields = {
   guardianPhone: z.string().optional(),
   relationOfGuardian: z.string().optional(),
   currentAddress: z.string().optional(),
-  permanentAddress: z.string().optional(),
+  permanentAddress: z.string().optional()
 };
 
 export const getStudentsSchema = z.object({
@@ -30,27 +30,27 @@ export const getStudentsSchema = z.object({
       name: z.string().optional(),
       className: z.string().optional(),
       section: z.string().optional(),
-      roll: z.string().optional(),
+      roll: z.string().optional()
     })
-    .strict(),
+    .strict()
 });
 
 export const studentIdParamSchema = z.object({
-  params: idParam,
+  params: idParam
 });
 
 export const addStudentSchema = z.object({
-  body: z.object(studentBodyFields),
+  body: z.object(studentBodyFields)
 });
 
 export const updateStudentSchema = z.object({
   params: idParam,
-  body: z.object(studentBodyFields).partial(),
+  body: z.object(studentBodyFields).partial()
 });
 
 export const studentStatusSchema = z.object({
   params: idParam,
   body: z.object({
-    status: z.boolean({ required_error: 'Status is required' }),
-  }),
+    status: z.boolean({ required_error: 'Status is required' })
+  })
 });

--- a/backend/src/modules/students/students-schema.ts
+++ b/backend/src/modules/students/students-schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 const idParam = z.object({
-  id: z.string().regex(/^\d+$/, 'Student ID must be a number')
+  id: z.string().regex(/^\d+$/, 'Student ID must be a number'),
 });
 
 const studentBodyFields = {
@@ -21,7 +21,7 @@ const studentBodyFields = {
   guardianPhone: z.string().optional(),
   relationOfGuardian: z.string().optional(),
   currentAddress: z.string().optional(),
-  permanentAddress: z.string().optional()
+  permanentAddress: z.string().optional(),
 };
 
 export const getStudentsSchema = z.object({
@@ -30,27 +30,27 @@ export const getStudentsSchema = z.object({
       name: z.string().optional(),
       className: z.string().optional(),
       section: z.string().optional(),
-      roll: z.string().optional()
+      roll: z.string().optional(),
     })
-    .strict()
+    .strict(),
 });
 
 export const studentIdParamSchema = z.object({
-  params: idParam
+  params: idParam,
 });
 
 export const addStudentSchema = z.object({
-  body: z.object(studentBodyFields)
+  body: z.object(studentBodyFields),
 });
 
 export const updateStudentSchema = z.object({
   params: idParam,
-  body: z.object(studentBodyFields).partial()
+  body: z.object(studentBodyFields).partial(),
 });
 
 export const studentStatusSchema = z.object({
   params: idParam,
   body: z.object({
-    status: z.boolean({ required_error: 'Status is required' })
-  })
+    status: z.boolean({ required_error: 'Status is required' }),
+  }),
 });

--- a/backend/src/modules/students/students-service.ts
+++ b/backend/src/modules/students/students-service.ts
@@ -4,7 +4,7 @@ import {
   findStudentDetail,
   findStudentToSetStatus,
   addOrUpdateStudent,
-  deleteStudentById,
+  deleteStudentById
 } from './students-repository';
 import { findUserById } from '../../shared/repository';
 
@@ -105,5 +105,5 @@ export {
   addNewStudent,
   setStudentStatus,
   updateStudent,
-  deleteStudent,
+  deleteStudent
 };

--- a/backend/src/modules/students/students-service.ts
+++ b/backend/src/modules/students/students-service.ts
@@ -3,7 +3,8 @@ import {
   findAllStudents,
   findStudentDetail,
   findStudentToSetStatus,
-  addOrUpdateStudent
+  addOrUpdateStudent,
+  deleteStudentById,
 } from './students-repository';
 import { findUserById } from '../../shared/repository';
 
@@ -57,6 +58,7 @@ const addNewStudent = async (payload: any): Promise<{ message: string }> => {
       return { message: ADD_STUDENT_AND_BUT_EMAIL_SEND_FAIL };
     }
   } catch (error) {
+    if (error instanceof ApiError) throw error;
     throw new ApiError(500, 'Unable to add student');
   }
 };
@@ -86,4 +88,22 @@ const setStudentStatus = async (payload: {
   return { message: 'Student status changed successfully' };
 };
 
-export { getAllStudents, getStudentDetail, addNewStudent, setStudentStatus, updateStudent };
+const deleteStudent = async (id: string | number): Promise<{ message: string }> => {
+  await checkStudentId(id);
+
+  const affectedRow = await deleteStudentById(id);
+  if (affectedRow <= 0) {
+    throw new ApiError(500, 'Unable to delete student');
+  }
+
+  return { message: 'Student deleted successfully' };
+};
+
+export {
+  getAllStudents,
+  getStudentDetail,
+  addNewStudent,
+  setStudentStatus,
+  updateStudent,
+  deleteStudent,
+};


### PR DESCRIPTION
## Summary
- PR #6 (CI/lint/format) was branched before PR #5 (CHAL-0006 CRUD) was merged. The prettier auto-format commit in PR #6 touched the student files with the old stub versions, and when PR #6 merged after PR #5, the merge overwrote CHAL-0006's implementations.
- This cherry-picks the CHAL-0006 changes back onto deploy with prettier formatting applied.

## Test plan
- [x] Verify student CRUD endpoints work (GET, POST, PUT, DELETE, status)
- [x] Verify `validateRequest` middleware is present on all student routes
- [x] Backend build, typecheck, lint, and format checks pass